### PR TITLE
chore(config) : SecurityConfig에 Cors 설정 추가 

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -53,7 +53,6 @@ public class SecurityConfig {
 		configuration.addAllowedHeader("*");
 		configuration.setAllowCredentials(true);
 		configuration.setMaxAge(1800L);
-		
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", configuration);
 		return source;

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -9,9 +9,15 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -26,7 +32,8 @@ public class SecurityConfig {
 			)
 			.sessionManagement((sessionManagement) ->
 				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-			);
+			)
+			.cors((cors) -> cors.configurationSource(corsConfigurationSource()));
 
 		return http.build();
 	}
@@ -34,5 +41,21 @@ public class SecurityConfig {
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.addAllowedOrigin("https://coach-coach.site");
+		configuration.addAllowedOrigin("https://api.coach-coach.site");
+		configuration.addAllowedMethod("*");
+		configuration.addAllowedHeader("*");
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(1800L);
+		
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/test/java/site/coach_coach/coach_coach_server/config/SecurityConfigTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/config/SecurityConfigTest.java
@@ -1,0 +1,43 @@
+package site.coach_coach.coach_coach_server.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SecurityConfigTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("CORS 설정 테스트 - 유효한 Origin")
+	public void corsConfigTest() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/test")
+				.header("Origin", "https://coach-coach.site"))
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "https://coach-coach.site"))
+			.andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Credentials", "true"));
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/test")
+				.header("Origin", "https://api.coach-coach.site"))
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(
+				MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "https://api.coach-coach.site"))
+			.andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Credentials", "true"));
+	}
+
+	@Test
+	@DisplayName("CORS 설정 테스트 - 유효하지 않은 Origin")
+	public void corsConfigInvalidOriginTest() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/test")
+				.header("Origin", "https://unauthorized-origin.com"))
+			.andExpect(MockMvcResultMatchers.status().isForbidden());
+	}
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- Spring Security의 CORS 설정을 추가하였습니다.
  - `SecurityConfig` 클래스에서 CORS 설정을 추가하여 특정 Origin에 대해서만 접근을 허용하도록 하였습니다.
  - `CorsConfigurationSource`를 설정하여 `https://coach-coach.site`와 `https://api.coach-coach.site`를 허용하며, 모든 HTTP 메서드와 헤더를 허용하였습니다.
- CORS 설정을 검증하기 위해 `SecurityConfigTest` 클래스를 작성하였습니다.
  - 유효한 Origin에 대해 올바른 CORS 헤더가 설정되었는지 확인하는 테스트를 추가하였습니다.
  - 유효하지 않은 Origin에 대해서는 요청이 차단되는지 검증하는 테스트를 추가하였습니다.

### PR Point
- `SecurityConfig`에서 CORS 설정이 올바르게 적용되었는지 확인해 주세요.
- `SecurityConfigTest`에서 작성된 CORS 관련 테스트가 설정을 정확히 검증하고 있는지 확인해 주세요.
  - 특히, CORS 설정이 제대로 적용되는지 확인하는 테스트와 유효하지 않은 Origin에 대한 처리 여부를 점검해 주세요.

### 📸 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요.

### 논의 사항 (선택)
- CORS 설정은 처음이라 부족한 부분이 있을 수 있습니다... 추가할 사항이 있으면 알려주세요! 

closed #40 
