### PR TITLE
feat(user, token) : 인증 api 구현 및 토큰 재발급 로직 수정

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
@@ -33,12 +33,13 @@ public class TokenFilter extends OncePerRequestFilter {
 			return;
 		}
 
-		String accessToken = getCookieValue(request, ACCESS_TOKEN);
-		String refreshToken = getCookieValue(request, REFRESH_TOKEN);
-		if (accessToken != null && tokenProvider.validateAccessToken(accessToken)) {
+		String accessToken = tokenProvider.getCookieValue(request, ACCESS_TOKEN);
+		String refreshToken = tokenProvider.getCookieValue(request, REFRESH_TOKEN);
+
+		if ((accessToken != null && tokenProvider.validateAccessToken(accessToken))) {
 			Authentication authentication = tokenProvider.getAuthentication(accessToken);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
-		} else if (accessToken != null && !tokenProvider.validateAccessToken(accessToken) && refreshToken != null) {
+		} else if ((accessToken == null || !tokenProvider.validateAccessToken(accessToken)) && refreshToken != null) {
 			boolean validRefreshToken = tokenProvider.validateRefreshToken(refreshToken);
 			boolean isRefreshToken = tokenProvider.existsRefreshToken(refreshToken);
 
@@ -55,18 +56,6 @@ public class TokenFilter extends OncePerRequestFilter {
 			}
 		}
 		filterChain.doFilter(request, response);
-	}
-
-	private String getCookieValue(HttpServletRequest request, String type) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if (type.equals(cookie.getName())) {
-					return cookie.getValue();
-				}
-			}
-		}
-		return null;
 	}
 
 	private void clearCookie(HttpServletResponse response, String type) {

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/domain/RefreshToken.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/domain/RefreshToken.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -22,7 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.coach_coach.coach_coach_server.user.domain.User;
 
-@Table(name = "refresh_tokens", uniqueConstraints = @UniqueConstraint(columnNames = "user_id"))
+@Table(name = "refresh_tokens")
 @Entity
 @Getter
 @Builder

--- a/src/main/java/site/coach_coach/coach_coach_server/common/utils/AuthenticationUtil.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/utils/AuthenticationUtil.java
@@ -1,0 +1,15 @@
+package site.coach_coach.coach_coach_server.common.utils;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationUtil {
+	public boolean isAuthenticated(Authentication authentication) {
+		if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+			return false;
+		}
+		return authentication.isAuthenticated();
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -37,8 +37,10 @@ public class SecurityConfig {
 			.addFilterBefore(jwtExceptionFilter, TokenFilter.class)
 			.authorizeHttpRequests((authorizeRequests) ->
 				authorizeRequests
-					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test").permitAll()
-					.anyRequest().authenticated()
+					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test", "/api/v1/auth")
+					.permitAll()
+					.anyRequest()
+					.authenticated()
 			)
 			.sessionManagement((sessionManagement) ->
 				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -1,7 +1,13 @@
 package site.coach_coach.coach_coach_server.user.controller;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.jwt.dto.TokenDto;
 import site.coach_coach.coach_coach_server.auth.jwt.service.RefreshTokenService;
+import site.coach_coach.coach_coach_server.common.utils.AuthenticationUtil;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.dto.LoginRequest;
 import site.coach_coach.coach_coach_server.user.dto.SignUpRequest;
@@ -25,6 +32,7 @@ public class UserController {
 	private final UserService userService;
 	private final RefreshTokenService refreshTokenService;
 	private final TokenProvider tokenProvider;
+	private final AuthenticationUtil authenticationUtil;
 
 	@PostMapping("/v1/auth/signup")
 	public ResponseEntity<Void> signup(@RequestBody @Valid SignUpRequest signUpRequest) {
@@ -41,5 +49,16 @@ public class UserController {
 		response.addCookie(tokenProvider.createCookie("refresh_token", tokenDto.refreshToken()));
 		refreshTokenService.createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/v1/auth")
+	public ResponseEntity<Map<String, Boolean>> auth() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		boolean isAuthenticated = authentication != null && authenticationUtil.isAuthenticated(authentication);
+
+		Map<String, Boolean> response = new HashMap<>();
+		response.put("isLogin", isAuthenticated);
+
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
 	@GetMapping("/v1/auth")
 	public ResponseEntity<Map<String, Boolean>> auth() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		boolean isAuthenticated = authentication != null && authenticationUtil.isAuthenticated(authentication);
+		boolean isAuthenticated = authenticationUtil.isAuthenticated(authentication);
 
 		Map<String, Boolean> response = new HashMap<>();
 		response.put("isLogin", isAuthenticated);

--- a/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
@@ -122,16 +122,6 @@ public class TokenProviderTest {
 	}
 
 	@Test
-	@DisplayName("토큰 유효성 검사 테스트")
-	public void validateTokenTest() {
-		String accessToken = tokenProvider.createAccessToken(user);
-		String refreshToken = tokenProvider.createRefreshToken(user);
-
-		assertThat(tokenProvider.validateAccessToken(accessToken)).isTrue();
-		assertThat(tokenProvider.validateRefreshToken(refreshToken)).isTrue();
-	}
-
-	@Test
 	@DisplayName("Refresh Token 존재 확인 테스트")
 	public void existsRefreshTokenTest() {
 		String refreshToken = tokenProvider.createRefreshToken(user);


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- refresh_token이 없거나 유효하지 않는 경우에는 에러 처리 했습니다.
- 만약 access_token이 만료된 경우 refresh_token으로 인해 새로운 토큰이 발급됩니다 

### PR Point
- Access Token 유효기간 = 30분, Refresh Token 유효기간 = 14일 입니다.
- 로그인을 했을 때 새로운 Refresh Token이 DB에 추가되는지 확인해 주세요.
- `application.properties` 에서 access token 유효기간을 짧게 임시로 변경하고 (ex: 5) `/auth` 호출 시 쿠키의 access_token이 재발급되는지 확인해주세요 

### 📸 스크린샷

|사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/c3a2bb86-3a6f-4515-a631-0f7b2712e48f)| 로그인 시 access_token값과 refresh_token 값이 재발급됩니다|
|![image](https://github.com/user-attachments/assets/bf58d9c0-a156-42da-9cf4-9cf8bdafda6f) | 로그인 후 호출 시 isLogin 값이 true로 나옵니다 |
|![image](https://github.com/user-attachments/assets/179f04e9-4790-4f0f-b99b-a7aecc33ab7a) | accesstoken이 만료되면 새로 발급됩니다 |

### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #57 
