### PR TITLE
feat(user) : logout api 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
@@ -46,7 +46,7 @@ public class TokenFilter extends OncePerRequestFilter {
 			if (validRefreshToken && isRefreshToken) {
 				String newAccessToken = tokenProvider.regenerateAccessToken(refreshToken);
 
-				clearCookie(response, ACCESS_TOKEN);
+				tokenProvider.clearCookie(response, ACCESS_TOKEN);
 
 				Cookie newAccessTokenCookie = tokenProvider.createCookie(ACCESS_TOKEN, newAccessToken);
 				response.addCookie(newAccessTokenCookie);
@@ -58,11 +58,4 @@ public class TokenFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 	}
 
-	private void clearCookie(HttpServletResponse response, String type) {
-		Cookie oldCookie = new Cookie(type, null);
-		oldCookie.setHttpOnly(true);
-		oldCookie.setPath("/");
-		oldCookie.setMaxAge(0);
-		response.addCookie(oldCookie);
-	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/repository/RefreshTokenRepository.java
@@ -11,5 +11,7 @@ import site.coach_coach.coach_coach_server.auth.jwt.domain.RefreshToken;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 	Optional<RefreshToken> findByRefreshToken(String token);
 
+	Optional<RefreshToken> findByUser_UserIdAndRefreshToken(Long userId, String refreshToken);
+
 	boolean existsByRefreshToken(String token);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/RefreshTokenService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/RefreshTokenService.java
@@ -34,7 +34,8 @@ public class RefreshTokenService {
 		refreshTokenRepository.save(newRefreshToken);
 	}
 
-	public void deleteRefreshToken(String refreshToken) {
-		refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
+	public void deleteRefreshToken(Long userId, String refreshToken) {
+		refreshTokenRepository.findByUser_UserIdAndRefreshToken(userId, refreshToken)
+			.ifPresent(refreshTokenRepository::delete);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/userdetails/CustomUserDetails.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/userdetails/CustomUserDetails.java
@@ -30,6 +30,10 @@ public class CustomUserDetails implements UserDetails {
 		return user.getNickname();
 	}
 
+	public Long getUserId() {
+		return user.getUserId();
+	}
+
 	public String getEmail() {
 		return user.getEmail();
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -26,8 +26,8 @@ public class GlobalExceptionHandler {
 	public static final String DEFAULT_MESSAGE = ErrorMessage.INVALID_REQUEST;
 
 	@ExceptionHandler(HandlerMethodValidationException.class)
-	public ResponseEntity<ErrorResponse> handlerMethodValidationException(HandlerMethodValidationException e) {
-		String errorMessage = e.getAllValidationResults()
+	public ResponseEntity<ErrorResponse> handlerMethodValidationException(HandlerMethodValidationException ex) {
+		String errorMessage = ex.getAllValidationResults()
 			.getFirst()
 			.getResolvableErrors()
 			.getFirst()

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 import site.coach_coach.coach_coach_server.auth.exception.ExpiredTokenException;
 import site.coach_coach.coach_coach_server.auth.exception.InvalidTokenException;
@@ -23,6 +24,19 @@ import site.coach_coach.coach_coach_server.user.exception.UserNotFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 	public static final String DEFAULT_MESSAGE = ErrorMessage.INVALID_REQUEST;
+
+	@ExceptionHandler(HandlerMethodValidationException.class)
+	public ResponseEntity<ErrorResponse> handlerMethodValidationException(HandlerMethodValidationException e) {
+		String errorMessage = e.getAllValidationResults()
+			.getFirst()
+			.getResolvableErrors()
+			.getFirst()
+			.getDefaultMessage();
+		ErrorResponse errorResponse = new ErrorResponse(errorMessage);
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(errorResponse);
+	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
@@ -55,9 +69,8 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(AuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException ex) {
-		ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-			.body(errorResponse);
+			.body(new ErrorResponse(ErrorMessage.NOT_FOUND_TOKEN));
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/main/java/site/coach_coach/coach_coach_server/config/ExceptionHandlerConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/ExceptionHandlerConfig.java
@@ -1,0 +1,33 @@
+package site.coach_coach.coach_coach_server.config;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class ExceptionHandlerConfig implements Customizer<ExceptionHandlingConfigurer<HttpSecurity>> {
+	@Override
+	public void customize(ExceptionHandlingConfigurer<HttpSecurity> httpSecurityExceptionHandlingConfigurer) {
+		httpSecurityExceptionHandlingConfigurer
+			.authenticationEntryPoint(this::handleAuthenticationException)
+			.accessDeniedHandler(this::handleAccessDeniedException);
+	}
+
+	private void handleAuthenticationException(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
+	}
+
+	private void handleAccessDeniedException(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN);
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -25,6 +25,7 @@ import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 public class SecurityConfig {
 	private final TokenProvider tokenProvider;
 	private final JwtExceptionFilter jwtExceptionFilter;
+	private final ExceptionHandlerConfig exceptionHandlerConfig;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -42,6 +43,7 @@ public class SecurityConfig {
 					.anyRequest()
 					.authenticated()
 			)
+			.exceptionHandling(exceptionHandlerConfig)
 			.sessionManagement((sessionManagement) ->
 				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -7,18 +7,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.jwt.dto.TokenDto;
 import site.coach_coach.coach_coach_server.auth.jwt.service.RefreshTokenService;
+import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.common.utils.AuthenticationUtil;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.dto.LoginRequest;
@@ -49,6 +52,18 @@ public class UserController {
 		response.addCookie(tokenProvider.createCookie("refresh_token", tokenDto.refreshToken()));
 		refreshTokenService.createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
 		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/v1/auth/logout")
+	public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authenticationUtil.isAuthenticated(authentication)) {
+			Long userId = ((CustomUserDetails)authentication.getPrincipal()).getUserId();
+
+			String refreshToken = userService.logout(request, response);
+			refreshTokenService.deleteRefreshToken(userId, refreshToken);
+		}
+		return ResponseEntity.noContent().build();
 	}
 
 	@GetMapping("/v1/auth")

--- a/src/main/java/site/coach_coach/coach_coach_server/user/service/UserService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/service/UserService.java
@@ -58,19 +58,13 @@ public class UserService {
 		String accessToken = tokenProvider.getCookieValue(request, "access_token");
 		String refreshToken = tokenProvider.getCookieValue(request, "refresh_token");
 
-		System.out.println("확인 시작");
-
 		if (accessToken != null && tokenProvider.validateAccessToken(accessToken)) {
-			System.out.println("accesstoken 삭제");
 			tokenProvider.clearCookie(response, "access_token");
 		}
-		System.out.println("accesstoken validation " + tokenProvider.validateAccessToken(accessToken));
 
 		if (refreshToken != null && tokenProvider.validateRefreshToken(refreshToken)) {
-			System.out.println("refreshtoken 삭제");
 			tokenProvider.clearCookie(response, "refresh_token");
 		}
-		System.out.println("refreshtoken validation " + tokenProvider.validateRefreshToken(refreshToken));
 
 		SecurityContextHolder.clearContext();
 		return refreshToken;

--- a/src/main/java/site/coach_coach/coach_coach_server/user/service/UserService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/service/UserService.java
@@ -1,8 +1,11 @@
 package site.coach_coach.coach_coach_server.user.service;
 
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
@@ -49,6 +52,28 @@ public class UserService {
 
 	public TokenDto createJwt(User user) {
 		return tokenProvider.generateJwt(user);
+	}
+
+	public String logout(HttpServletRequest request, HttpServletResponse response) {
+		String accessToken = tokenProvider.getCookieValue(request, "access_token");
+		String refreshToken = tokenProvider.getCookieValue(request, "refresh_token");
+
+		System.out.println("확인 시작");
+
+		if (accessToken != null && tokenProvider.validateAccessToken(accessToken)) {
+			System.out.println("accesstoken 삭제");
+			tokenProvider.clearCookie(response, "access_token");
+		}
+		System.out.println("accesstoken validation " + tokenProvider.validateAccessToken(accessToken));
+
+		if (refreshToken != null && tokenProvider.validateRefreshToken(refreshToken)) {
+			System.out.println("refreshtoken 삭제");
+			tokenProvider.clearCookie(response, "refresh_token");
+		}
+		System.out.println("refreshtoken validation " + tokenProvider.validateRefreshToken(refreshToken));
+
+		SecurityContextHolder.clearContext();
+		return refreshToken;
 	}
 
 	private User buildUser(SignUpRequest signUpRequest) {

--- a/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/service/RefreshTokenServiceTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/service/RefreshTokenServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -68,25 +67,5 @@ public class RefreshTokenServiceTest {
 		);
 
 		verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
-	}
-
-	@Test
-	@DisplayName("리프레시 토큰 db에서 삭제")
-	public void deleteRefreshTokenTest() {
-		when(refreshTokenRepository.findByRefreshToken(tokenDto.refreshToken())).thenReturn(Optional.of(refreshToken));
-
-		refreshTokenService.deleteRefreshToken(tokenDto.refreshToken());
-
-		verify(refreshTokenRepository, times(1)).delete(refreshToken);
-	}
-
-	@Test
-	@DisplayName("리프레시 토큰 삭제 실패")
-	public void deleteNotExistingRefreshTokenTest() {
-		when(refreshTokenRepository.findByRefreshToken(tokenDto.refreshToken())).thenReturn(Optional.empty());
-
-		refreshTokenService.deleteRefreshToken(tokenDto.refreshToken());
-
-		verify(refreshTokenRepository, never()).delete(any());
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 로그아웃 api를 구현했습니다
- 로그아웃 시 refresh_tokens 테이블에 있는 refresh token이 사라집니다
- 쿠키 또한 삭제됩니다.

### PR Point
- refresh_tokens 테이블에서 userId와 refreshToken 값으로 삭제를 진행합니다
  - 만약 사용자가 여러 기기로 로그인 했을 경우 한 기기에서 로그아웃을 했다고, 모든 기기에서 삭제되는 것을 막기 위해서 입니다.
  - 따라서 refresh_tokens table의 userId 값은 unique 값이 아닙니다! 
- 현재 토큰 로직 수정이 필요하여 리팩토링 해야되므로, 로그인 하지 않은 경우에서 로그아웃할 때 401에러만 발생하고 에러 메시지가 뜨지 않습니다.
  - 로그아웃 로직 구현 후 token 로직 수정을 통해 해결할 것입니다

### 📸 스크린샷

|사진|설명|
|---|---|
| ![image](https://github.com/user-attachments/assets/2b756f2a-a21d-4c72-99a0-e85e5e0e915b) | 로그아웃한 경우 쿠키 삭제 |
| ![image](https://github.com/user-attachments/assets/689047f6-1de4-4585-871a-606bd83a1ce5) | /auth 로 검증 시 false |

### 논의 사항 (선택)
- test 코드는 기능 추가 후에 작성할 예정입니다... 느려서 죄송합니다 ㅠ

closed #54 
