### PR TITLE
refactor(user) : 토큰 재발급 api 추가 & refresh token 재발급 로직 수정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,3 @@ dependencies {
 jar {
     enabled = false
 }
-
-test {
-    useJUnitPlatform()
-}

--- a/build.gradle
+++ b/build.gradle
@@ -54,3 +54,7 @@ dependencies {
 jar {
     enabled = false
 }
+
+test {
+    useJUnitPlatform()
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/JwtExceptionFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/JwtExceptionFilter.java
@@ -1,15 +1,17 @@
 package site.coach_coach.coach_coach_server.auth.jwt;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,28 +31,12 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 
 		try {
 			filterChain.doFilter(request, response);
-		} catch (JwtException ex) {
-			String message = ex.getMessage();
-
-			if (ErrorMessage.EXPIRED_TOKEN.equals(message)) {
-				setErrorResponse(response, ErrorMessage.EXPIRED_TOKEN);
-			} else if (ErrorMessage.NOT_FOUND_TOKEN.equals(message)) {
-				setErrorResponse(response, ErrorMessage.NOT_FOUND_TOKEN);
-			} else {
-				setErrorResponse(response, ErrorMessage.INVALID_TOKEN);
-			}
+		} catch (ExpiredJwtException e) {
+			throw new JwtException(ErrorMessage.EXPIRED_TOKEN);
+		} catch (SignatureException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+			throw new JwtException(ErrorMessage.INVALID_TOKEN);
+		} catch (JwtException e) {
+			throw new JwtException(e.getMessage());
 		}
-	}
-
-	private void setErrorResponse(HttpServletResponse response, String message)
-		throws IOException {
-		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-		response.setContentType("application/json");
-
-		Map<String, String> errorResponse = new HashMap<>();
-		errorResponse.put("message", message);
-
-		String jsonResponse = objectMapper.writeValueAsString(errorResponse);
-		response.getWriter().write(jsonResponse);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TokenFilter extends OncePerRequestFilter {
 	private static final String ACCESS_TOKEN = "access_token";
-	private static final String REFRESH_TOKEN = "refresh_token";
 
 	private final TokenProvider tokenProvider;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
@@ -9,7 +9,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -34,26 +33,10 @@ public class TokenFilter extends OncePerRequestFilter {
 		}
 
 		String accessToken = tokenProvider.getCookieValue(request, ACCESS_TOKEN);
-		String refreshToken = tokenProvider.getCookieValue(request, REFRESH_TOKEN);
 
-		if ((accessToken != null && tokenProvider.validateAccessToken(accessToken))) {
+		if (accessToken != null && tokenProvider.validateAccessToken(accessToken)) {
 			Authentication authentication = tokenProvider.getAuthentication(accessToken);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
-		} else if ((accessToken == null || !tokenProvider.validateAccessToken(accessToken)) && refreshToken != null) {
-			boolean validRefreshToken = tokenProvider.validateRefreshToken(refreshToken);
-			boolean isRefreshToken = tokenProvider.existsRefreshToken(refreshToken);
-
-			if (validRefreshToken && isRefreshToken) {
-				String newAccessToken = tokenProvider.regenerateAccessToken(refreshToken);
-
-				tokenProvider.clearCookie(response, ACCESS_TOKEN);
-
-				Cookie newAccessTokenCookie = tokenProvider.createCookie(ACCESS_TOKEN, newAccessToken);
-				response.addCookie(newAccessTokenCookie);
-
-				Authentication authentication = tokenProvider.getAuthentication(newAccessToken);
-				SecurityContextHolder.getContext().setAuthentication(authentication);
-			}
 		}
 		filterChain.doFilter(request, response);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProvider.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProvider.java
@@ -1,5 +1,6 @@
 package site.coach_coach.coach_coach_server.auth.jwt;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 
@@ -121,15 +122,20 @@ public class TokenProvider {
 	}
 
 	public String getCookieValue(HttpServletRequest request, String type) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if (type.equals(cookie.getName())) {
-					return cookie.getValue();
-				}
-			}
+		if (request == null || type == null) {
+			throw new IllegalArgumentException();
 		}
-		return null;
+
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return null;
+		}
+
+		return Arrays.stream(cookies)
+			.filter(cookie -> type.equals(cookie.getName()))
+			.map(Cookie::getValue)
+			.findFirst()
+			.orElse(null);
 	}
 
 	public Authentication getAuthentication(String token) {
@@ -146,34 +152,13 @@ public class TokenProvider {
 		return extractClaims(token).getSubject();
 	}
 
-	public boolean validateAccessToken(String token) {
+	public boolean validateToken(String token, String type) {
 		try {
 			Claims claims = extractClaims(token);
-
-			if (!claims.get("token_type").equals("access_token")) {
+			if (!claims.get("token_type").equals(type)) {
 				throw new JwtException(ErrorMessage.NOT_FOUND_TOKEN);
 			}
-
 			return !claims.getExpiration().before(new Date());
-		} catch (ExpiredJwtException e) {
-			return false;
-		} catch (SignatureException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-			throw new JwtException(ErrorMessage.INVALID_TOKEN);
-		} catch (JwtException e) {
-			throw new JwtException(e.getMessage());
-		}
-	}
-
-	public boolean validateRefreshToken(String token) {
-		try {
-			Claims claims = extractClaims(token);
-			if (!claims.get("token_type").equals("refresh_token")) {
-				throw new JwtException(ErrorMessage.NOT_FOUND_TOKEN);
-			}
-			if (claims.getExpiration().before(new Date())) {
-				throw new JwtException(ErrorMessage.EXPIRED_TOKEN);
-			}
-			return existsRefreshToken(token);
 		} catch (ExpiredJwtException e) {
 			throw new JwtException(ErrorMessage.EXPIRED_TOKEN);
 		} catch (SignatureException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
@@ -181,6 +166,14 @@ public class TokenProvider {
 		} catch (JwtException e) {
 			throw new JwtException(e.getMessage());
 		}
+	}
+
+	public boolean validateAccessToken(String token) {
+		return validateToken(token, "access_token");
+	}
+
+	public boolean validateRefreshToken(String token) {
+		return validateToken(token, "refresh_token");
 	}
 
 	public boolean existsRefreshToken(String refreshToken) {

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProvider.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProvider.java
@@ -173,16 +173,20 @@ public class TokenProvider {
 	}
 
 	public boolean validateRefreshToken(String token) {
-		return validateToken(token, "refresh_token");
+		return validateToken(token, "refresh_token") && existsRefreshToken(token);
 	}
 
 	public boolean existsRefreshToken(String refreshToken) {
-		return refreshTokenRepository.existsByRefreshToken(refreshToken);
+		if (refreshTokenRepository.existsByRefreshToken(refreshToken)) {
+			return true;
+		} else {
+			throw new JwtException(ErrorMessage.NOT_FOUND_TOKEN);
+		}
 	}
 
 	public String regenerateAccessToken(String refreshToken) {
-		String userId = extractClaims(refreshToken).getSubject();
-		CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(userId);
+		Long userId = getUserId(refreshToken);
+		CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));
 		User user = userDetails.getUser();
 
 		return createAccessToken(user);

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProvider.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProvider.java
@@ -139,7 +139,7 @@ public class TokenProvider {
 	}
 
 	public Authentication getAuthentication(String token) {
-		CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(getUserId(token));
+		CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(getUserId(token).toString());
 
 		return new UsernamePasswordAuthenticationToken(userDetails, "", Collections.emptyList());
 	}
@@ -148,8 +148,8 @@ public class TokenProvider {
 		return jwtParser.parseClaimsJws(token).getBody();
 	}
 
-	public String getUserId(String token) {
-		return extractClaims(token).getSubject();
+	public Long getUserId(String token) {
+		return Long.parseLong(extractClaims(token).getSubject());
 	}
 
 	public boolean validateToken(String token, String type) {

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenService.java
@@ -7,7 +7,6 @@ import java.time.ZoneId;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import io.jsonwebtoken.JwtException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.exception.InvalidTokenException;
@@ -48,15 +47,15 @@ public class TokenService {
 	}
 
 	public String reissueAccessToken(String refreshToken) {
-		if (refreshToken == null) {
-			throw new JwtException(ErrorMessage.NOT_FOUND_TOKEN);
-		}
 		if (!tokenProvider.validateRefreshToken(refreshToken)) {
 			throw new InvalidTokenException(ErrorMessage.INVALID_TOKEN);
 		}
+		System.out.println(
+			"tokenProvider.validateRefreshToken(refreshToken)" + tokenProvider.validateRefreshToken(refreshToken));
 
 		userRepository.findByUserId(tokenProvider.getUserId(refreshToken))
 			.orElseThrow(() -> new UsernameNotFoundException(ErrorMessage.NOT_FOUND_USER));
+		System.out.println(userRepository.findByUserId(tokenProvider.getUserId(refreshToken)));
 
 		return tokenProvider.regenerateAccessToken(refreshToken);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenService.java
@@ -50,12 +50,9 @@ public class TokenService {
 		if (!tokenProvider.validateRefreshToken(refreshToken)) {
 			throw new InvalidTokenException(ErrorMessage.INVALID_TOKEN);
 		}
-		System.out.println(
-			"tokenProvider.validateRefreshToken(refreshToken)" + tokenProvider.validateRefreshToken(refreshToken));
 
 		userRepository.findByUserId(tokenProvider.getUserId(refreshToken))
 			.orElseThrow(() -> new UsernameNotFoundException(ErrorMessage.NOT_FOUND_USER));
-		System.out.println(userRepository.findByUserId(tokenProvider.getUserId(refreshToken)));
 
 		return tokenProvider.regenerateAccessToken(refreshToken);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
+import io.jsonwebtoken.JwtException;
 import site.coach_coach.coach_coach_server.auth.exception.ExpiredTokenException;
 import site.coach_coach.coach_coach_server.auth.exception.InvalidTokenException;
 import site.coach_coach.coach_coach_server.common.validation.ErrorMessage;
@@ -65,6 +66,12 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.status(HttpStatus.NOT_FOUND)
 			.body(errorResponse);
+	}
+
+	@ExceptionHandler(JwtException.class)
+	public ResponseEntity<ErrorResponse> handleJwtException(JwtException ex) {
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+			.body(new ErrorResponse(ex.getMessage()));
 	}
 
 	@ExceptionHandler(AuthenticationException.class)

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
 			.addFilterBefore(jwtExceptionFilter, TokenFilter.class)
 			.authorizeHttpRequests((authorizeRequests) ->
 				authorizeRequests
-					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test")
+					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/auth/reissue",
+						"/api/v1/test")
 					.permitAll()
 					.anyRequest()
 					.authenticated()

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
 			.addFilterBefore(jwtExceptionFilter, TokenFilter.class)
 			.authorizeHttpRequests((authorizeRequests) ->
 				authorizeRequests
-					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test", "/api/v1/auth")
+					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test")
 					.permitAll()
 					.anyRequest()
 					.authenticated()

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -67,12 +67,9 @@ public class UserController {
 	@GetMapping("/v1/auth/reissue")
 	public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
 		String refreshToken = tokenProvider.getCookieValue(request, "refresh_token");
-		System.out.println("refresh token 가져오기 " + refreshToken);
 
 		String newAccessToken = tokenService.reissueAccessToken(refreshToken);
-		System.out.println("발급완료");
 		tokenProvider.clearCookie(response, "access_token");
-		System.out.println("삭제완료");
 
 		Cookie newAccessTokenCookie = tokenProvider.createCookie("access_token", newAccessToken);
 		response.addCookie(newAccessTokenCookie);

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -1,12 +1,10 @@
 package site.coach_coach.coach_coach_server.user.controller;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,13 +12,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.jwt.dto.TokenDto;
-import site.coach_coach.coach_coach_server.auth.jwt.service.RefreshTokenService;
+import site.coach_coach.coach_coach_server.auth.jwt.service.TokenService;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.common.utils.AuthenticationUtil;
 import site.coach_coach.coach_coach_server.user.domain.User;
@@ -33,7 +32,7 @@ import site.coach_coach.coach_coach_server.user.service.UserService;
 @RequiredArgsConstructor
 public class UserController {
 	private final UserService userService;
-	private final RefreshTokenService refreshTokenService;
+	private final TokenService tokenService;
 	private final TokenProvider tokenProvider;
 	private final AuthenticationUtil authenticationUtil;
 
@@ -50,7 +49,7 @@ public class UserController {
 
 		response.addCookie(tokenProvider.createCookie("access_token", tokenDto.accessToken()));
 		response.addCookie(tokenProvider.createCookie("refresh_token", tokenDto.refreshToken()));
-		refreshTokenService.createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
+		tokenService.createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
 		return ResponseEntity.ok().build();
 	}
 
@@ -61,19 +60,23 @@ public class UserController {
 			Long userId = ((CustomUserDetails)authentication.getPrincipal()).getUserId();
 
 			String refreshToken = userService.logout(request, response);
-			refreshTokenService.deleteRefreshToken(userId, refreshToken);
+			tokenService.deleteRefreshToken(userId, refreshToken);
 		}
 		return ResponseEntity.noContent().build();
 	}
 
-	@GetMapping("/v1/auth")
-	public ResponseEntity<Map<String, Boolean>> auth() {
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		boolean isAuthenticated = authenticationUtil.isAuthenticated(authentication);
+	@GetMapping("/v1/auth/reissue")
+	public ResponseEntity<Void> reissue(@CookieValue(name = "refresh_token") HttpServletRequest request,
+		HttpServletResponse response) {
+		String refreshToken = tokenProvider.getCookieValue(request, "refresh_token");
+		tokenService.reissueAccessToken(refreshToken);
 
-		Map<String, Boolean> response = new HashMap<>();
-		response.put("isLogin", isAuthenticated);
+		tokenProvider.clearCookie(response, "access_token");
+		String newAccessToken = tokenService.reissueAccessToken(refreshToken);
 
-		return ResponseEntity.ok(response);
+		Cookie newAccessTokenCookie = tokenProvider.createCookie("access_token", newAccessToken);
+		response.addCookie(newAccessTokenCookie);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,13 +65,14 @@ public class UserController {
 	}
 
 	@GetMapping("/v1/auth/reissue")
-	public ResponseEntity<Void> reissue(@CookieValue(name = "refresh_token") HttpServletRequest request,
-		HttpServletResponse response) {
+	public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
 		String refreshToken = tokenProvider.getCookieValue(request, "refresh_token");
-		tokenService.reissueAccessToken(refreshToken);
+		System.out.println("refresh token 가져오기 " + refreshToken);
 
-		tokenProvider.clearCookie(response, "access_token");
 		String newAccessToken = tokenService.reissueAccessToken(refreshToken);
+		System.out.println("발급완료");
+		tokenProvider.clearCookie(response, "access_token");
+		System.out.println("삭제완료");
 
 		Cookie newAccessTokenCookie = tokenProvider.createCookie("access_token", newAccessToken);
 		response.addCookie(newAccessTokenCookie);

--- a/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
@@ -9,9 +9,9 @@ import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.TestPropertySource;
 
@@ -26,15 +26,15 @@ import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetailsSer
 import site.coach_coach.coach_coach_server.user.domain.User;
 
 @TestPropertySource(locations = "/application.properties")
-@SpringBootTest(classes = TokenProviderTest.class)
+@SpringBootTest
 public class TokenProviderTest {
 	@Autowired
 	private JwtProperties jwtProperties;
 
-	@Mock
+	@MockBean
 	private CustomUserDetailsService customUserDetailsService;
 
-	@Mock
+	@MockBean
 	private RefreshTokenRepository refreshTokenRepository;
 
 	@Autowired

--- a/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
@@ -26,7 +26,7 @@ import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetailsSer
 import site.coach_coach.coach_coach_server.user.domain.User;
 
 @TestPropertySource(locations = "/application.properties")
-@SpringBootTest
+@SpringBootTest(classes = TokenProviderTest.class)
 public class TokenProviderTest {
 	@Autowired
 	private JwtProperties jwtProperties;

--- a/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
@@ -66,7 +66,7 @@ public class TokenProviderTest {
 		assertThat(claims.getSubject()).isEqualTo(user.getUserId().toString());
 		assertThat(claims.get("nickname")).isEqualTo(user.getNickname());
 		assertThat(claims.get("email")).isEqualTo(user.getEmail());
-		assertThat(claims.get("token_type")).isEqualTo("access");
+		assertThat(claims.get("token_type")).isEqualTo("access_token");
 		assertThat(claims.getExpiration()).isAfter(new Date());
 	}
 
@@ -78,7 +78,7 @@ public class TokenProviderTest {
 
 		Claims claims = tokenProvider.extractClaims(refreshToken);
 		assertThat(claims.getSubject()).isEqualTo(user.getUserId().toString());
-		assertThat(claims.get("token_type")).isEqualTo("refresh");
+		assertThat(claims.get("token_type")).isEqualTo("refresh_token");
 		assertThat(claims.getExpiration()).isAfter(new Date());
 	}
 
@@ -140,7 +140,7 @@ public class TokenProviderTest {
 		assertThat(newAccessToken).isNotNull();
 		Claims claims = tokenProvider.extractClaims(newAccessToken);
 		assertThat(claims.getSubject()).isEqualTo(user.getUserId().toString());
-		assertThat(claims.get("token_type")).isEqualTo("access");
+		assertThat(claims.get("token_type")).isEqualTo("access_token");
 		assertThat(claims.getExpiration()).isAfter(new Date());
 	}
 }

--- a/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenServiceTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenServiceTest.java
@@ -22,12 +22,12 @@ import site.coach_coach.coach_coach_server.auth.jwt.repository.RefreshTokenRepos
 import site.coach_coach.coach_coach_server.user.domain.User;
 
 @ExtendWith(MockitoExtension.class)
-public class RefreshTokenServiceTest {
+public class TokenServiceTest {
 	@Mock
 	private RefreshTokenRepository refreshTokenRepository;
 
 	@InjectMocks
-	private RefreshTokenService refreshTokenService;
+	private TokenService tokenService;
 
 	private User user;
 	private TokenDto tokenDto;
@@ -59,7 +59,7 @@ public class RefreshTokenServiceTest {
 	@Test
 	@DisplayName("리프레시 토큰 db에 저장")
 	public void createRefreshTokenTest() {
-		refreshTokenService.createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
+		tokenService.createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
 
 		LocalDateTime expectedExpireDate = LocalDateTime.ofInstant(
 			Instant.ofEpochMilli(tokenDto.refreshTokenExpiresIn()),

--- a/src/test/java/site/coach_coach/coach_coach_server/config/SecurityConfigTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/config/SecurityConfigTest.java
@@ -26,10 +26,10 @@ public class SecurityConfigTest {
 			.andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Credentials", "true"));
 
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/test")
-				.header("Origin", "http://localhost:3000"))
+				.header("Origin", "http://localhost:5173"))
 			.andExpect(MockMvcResultMatchers.status().isOk())
 			.andExpect(
-				MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "http://localhost:3000"))
+				MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "http://localhost:5173"))
 			.andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Credentials", "true"));
 	}
 

--- a/src/test/java/site/coach_coach/coach_coach_server/user/controller/UserControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/user/controller/UserControllerTest.java
@@ -24,7 +24,9 @@ import jakarta.servlet.http.Cookie;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.jwt.dto.TokenDto;
 import site.coach_coach.coach_coach_server.auth.jwt.service.TokenService;
+import site.coach_coach.coach_coach_server.common.utils.AuthenticationUtil;
 import site.coach_coach.coach_coach_server.common.validation.ErrorMessage;
+import site.coach_coach.coach_coach_server.config.ExceptionHandlerConfig;
 import site.coach_coach.coach_coach_server.config.SecurityConfig;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.dto.LoginRequest;
@@ -34,7 +36,7 @@ import site.coach_coach.coach_coach_server.user.exception.UserNotFoundException;
 import site.coach_coach.coach_coach_server.user.service.UserService;
 
 @WebMvcTest(UserController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, ExceptionHandlerConfig.class})
 public class UserControllerTest {
 
 	@Autowired
@@ -48,6 +50,9 @@ public class UserControllerTest {
 
 	@MockBean
 	private TokenService tokenService;
+
+	@MockBean
+	private AuthenticationUtil authenticationUtil;
 
 	private ObjectMapper objectMapper;
 	Faker faker = new Faker();

--- a/src/test/java/site/coach_coach/coach_coach_server/user/controller/UserControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/user/controller/UserControllerTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.jwt.dto.TokenDto;
-import site.coach_coach.coach_coach_server.auth.jwt.service.RefreshTokenService;
+import site.coach_coach.coach_coach_server.auth.jwt.service.TokenService;
 import site.coach_coach.coach_coach_server.common.validation.ErrorMessage;
 import site.coach_coach.coach_coach_server.config.SecurityConfig;
 import site.coach_coach.coach_coach_server.user.domain.User;
@@ -47,7 +47,7 @@ public class UserControllerTest {
 	private TokenProvider tokenProvider;
 
 	@MockBean
-	private RefreshTokenService refreshTokenService;
+	private TokenService tokenService;
 
 	private ObjectMapper objectMapper;
 	Faker faker = new Faker();
@@ -214,7 +214,7 @@ public class UserControllerTest {
 			new Cookie("access_token", tokenDto.accessToken()));
 		when(tokenProvider.createCookie(eq("refresh_token"), anyString())).thenReturn(
 			new Cookie("refresh_token", tokenDto.refreshToken()));
-		doNothing().when(refreshTokenService).createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
+		doNothing().when(tokenService).createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -228,7 +228,7 @@ public class UserControllerTest {
 		verify(userService, times(1)).createJwt(user);
 		verify(tokenProvider, times(1)).createCookie("access_token", tokenDto.accessToken());
 		verify(tokenProvider, times(1)).createCookie("refresh_token", tokenDto.refreshToken());
-		verify(refreshTokenService, times(1)).createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
+		verify(tokenService, times(1)).createRefreshToken(user, tokenDto.refreshToken(), tokenDto);
 	}
 
 	@Test


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 기존의 `/auth` api를 삭제하였습니다.
- `/reissue` api를 추가하였습니다.
- 로그인 후 `/reissue` 호출 시 access token이 재발급됩니다 (refresh token이 있는 경우)
- 만약 refresh token이 만료되었거나, 로그아웃인 경우 에러 메시지가 발생합니다.

### PR Point
- api 호출시 토큰이 잘 생성되는지 확인해주세요!

### 📸 스크린샷

|사진|설명|
|---|---|
| ![image](https://github.com/user-attachments/assets/e33d7907-f2d2-4a2a-a847-c142c5c62644) | 로그인 시 토큰 발행 |
| ![image](https://github.com/user-attachments/assets/fd9c6f3e-42b2-4b58-a459-99a7cdecf010) | 재발급 api 호출 시 새 access token 생성|
| ![image](https://github.com/user-attachments/assets/b675c906-2728-45ee-a94e-8be59e782001) | 리프레시 토큰 만료 or 없거나 or 유효하지 않은 경우 에러|


### 논의 사항 (선택)
- refresh token은 갱신하지 않습니다 
- 기능 수정하느라 에러 처리가 미흡합니다 ㅠㅠ 
  - 추후 로그아웃 로직 수정할 때 추가예정입니다! 
- 테스트 코드는 중복 체크 확인 api까지 완료하면 작성하겠습니다 (인증 부분 기능 완료 후 작성 예정)

closed #59 