### PR TITLE
feat(user) : 닉네임 중복 확인, 이메일 중복 확인 api 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
@@ -26,7 +26,9 @@ public class TokenFilter extends OncePerRequestFilter {
 		response.setCharacterEncoding("utf-8");
 
 		String requestUri = request.getRequestURI();
-		if (requestUri.equals("/api/v1/auth/login") || requestUri.equals("/api/v1/auth/signup")) {
+		if (requestUri.equals("/api/v1/auth/login") || requestUri.equals("/api/v1/auth/signup") || requestUri.equals(
+			"/api/v1/test") || requestUri.equals("/api/v1/auth/check-email") || requestUri.equals(
+			"/api/v1/auth/check-nickname")) {
 			filterChain.doFilter(request, response);
 			return;
 		}
@@ -39,5 +41,4 @@ public class TokenFilter extends OncePerRequestFilter {
 		}
 		filterChain.doFilter(request, response);
 	}
-
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
 			.addFilterBefore(jwtExceptionFilter, TokenFilter.class)
 			.authorizeHttpRequests((authorizeRequests) ->
 				authorizeRequests
-					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test")
+					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test",
+						"/api/v1/auth/check-email", "/api/v1/auth/check-nickname")
 					.permitAll()
 					.anyRequest()
 					.authenticated()

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -16,6 +16,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.jwt.dto.TokenDto;
@@ -26,6 +27,7 @@ import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.dto.LoginRequest;
 import site.coach_coach.coach_coach_server.user.dto.SignUpRequest;
 import site.coach_coach.coach_coach_server.user.service.UserService;
+import site.coach_coach.coach_coach_server.user.validation.Nickname;
 
 @RestController
 @RequestMapping("/api")
@@ -70,13 +72,13 @@ public class UserController {
 	}
 
 	@GetMapping("/v1/auth/check-nickname")
-	public ResponseEntity<Void> checkNickname(@RequestParam("nickname") String nickname) {
+	public ResponseEntity<Void> checkNickname(@RequestParam("nickname") @Nickname String nickname) {
 		userService.checkNicknameDuplicate(nickname);
 		return ResponseEntity.noContent().build();
 	}
 
 	@GetMapping("/v1/auth/check-email")
-	public ResponseEntity<Void> checkEmail(@RequestParam("email") String email) {
+	public ResponseEntity<Void> checkEmail(@RequestParam("email") @Email String email) {
 		userService.checkEmailDuplicate(email);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/controller/UserController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.Cookie;
@@ -65,6 +66,18 @@ public class UserController {
 
 		SecurityContextHolder.clearContext();
 
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/v1/auth/check-nickname")
+	public ResponseEntity<Void> checkNickname(@RequestParam("nickname") String nickname) {
+		userService.checkNicknameDuplicate(nickname);
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/v1/auth/check-email")
+	public ResponseEntity<Void> checkEmail(@RequestParam("email") String email) {
+		userService.checkEmailDuplicate(email);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/site/coach_coach/coach_coach_server/user/service/UserService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/service/UserService.java
@@ -17,20 +17,27 @@ import site.coach_coach.coach_coach_server.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final TokenProvider tokenProvider;
 
-	@Transactional
-	public void signup(SignUpRequest signUpRequest) {
-		if (userRepository.existsByNickname(signUpRequest.nickname())) {
+	public void checkNicknameDuplicate(String nickname) {
+		if (userRepository.existsByNickname(nickname)) {
 			throw new UserAlreadyExistException(ErrorMessage.DUPLICATE_NICKNAME);
 		}
-		if (userRepository.existsByEmail(signUpRequest.email())) {
+	}
+
+	public void checkEmailDuplicate(String email) {
+		if (userRepository.existsByEmail(email)) {
 			throw new UserAlreadyExistException(ErrorMessage.DUPLICATE_EMAIL);
 		}
+	}
 
+	public void signup(SignUpRequest signUpRequest) {
+		checkNicknameDuplicate(signUpRequest.nickname());
+		checkEmailDuplicate(signUpRequest.email());
 		User user = buildUser(signUpRequest);
 		userRepository.save(user);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/user/validation/Nickname.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/validation/Nickname.java
@@ -12,7 +12,7 @@ import site.coach_coach.coach_coach_server.common.validation.ErrorMessage;
 
 @Documented
 @Constraint(validatedBy = NicknameValidator.class)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Nickname {
 	String REGEX =


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 닉네임 중복 확인, 이메일 중복 확인 api를 작성했습니다.
- 중복 시 409 에러, 중복이 아니면 204 성공입니다

### 📸 스크린샷

|사진|설명|
|---|---|
| ![image](https://github.com/user-attachments/assets/65b28e5a-4c12-4705-a3e4-b1caca377e03) | 닉네임 중복 |
| ![image](https://github.com/user-attachments/assets/16713f3e-427b-452a-950e-70f924ea8033) | 닉네임 중복 아님 |
| ![image](https://github.com/user-attachments/assets/db61e12e-98bb-4112-8a2a-9ad8a4f72de1) | 이메일 중복 |
| ![image](https://github.com/user-attachments/assets/2f2a2abd-8b03-4d43-af7a-723bf74cf231) | 이메일 중복 아님 |


closed #53 
