### PR TITLE
feature(routine) : 루틴 목록 관련 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/service/TokenService.java
@@ -62,7 +62,7 @@ public class TokenService {
 		}
 
 		userRepository.findByUserId(tokenProvider.getUserId(refreshToken))
-			.orElseThrow(() -> new UsernameNotFoundException(ErrorMessage.NOT_FOUND_USER));
+			.orElseThrow(() -> new UsernameNotFoundException(ErrorMessage.INVALID_USER));
 
 		return tokenProvider.regenerateAccessToken(refreshToken);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -1,12 +1,16 @@
 package site.coach_coach.coach_coach_server.coach.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import site.coach_coach.coach_coach_server.coach.domain.Coach;
 
 @Repository
 public interface CoachRepository extends JpaRepository<Coach, Long> {
-
+	@Query("SELECT c.coachId FROM Coach c WHERE c.user.userId = :userId")
+	Optional<Long> findCoachIdByUserId(@Param("userId") Long userId);
 }
-

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -54,9 +54,9 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(UserNotFoundException.class)
 	public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException ex) {
-		ErrorResponse errorResponse = new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage());
+		ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
 		log.info("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
-		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
 			.body(errorResponse);
 	}
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/validation/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/validation/ErrorMessage.java
@@ -22,14 +22,15 @@ public final class ErrorMessage {
 	public static final String DUPLICATE_EMAIL = "이미 사용중인 이메일입니다.";
 	public static final String DUPLICATE_NICKNAME = "이미 사용중인 닉네임입니다.";
 
-	public static final String NOT_FOUND_USER = "회원 정보가 잘못되었습니다.";
+	public static final String INVALID_USER = "회원 정보가 잘못되었습니다.";
 
+	public static final String NOT_FOUND_USER = "존재하지 않는 회원입니다.";
+	public static final String NOT_FOUND_COACH = "존재하지 않는 코치입니다.";
 	public static final String NOT_FOUND_TOKEN = "토큰이 존재하지 않습니다.";
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 
 	public static final String NOT_MATCHING = "매칭되지 않은 대상입니다.";
-	public static final String NOT_FOUND_COACH = "존재하지 않는 코치입니다.";
 }
 

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineListRequest;
+import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
 import site.coach_coach.coach_coach_server.routine.services.RoutineService;
 
 @RestController
@@ -29,23 +30,26 @@ public class RoutineController {
 		@RequestParam(name = "userId", required = false) Long userIdParam) {
 
 		Long userIdByJwt = userDetails.getUserId();
-		RoutineListRequest routineListRequest = createRoutineListRequest(userIdParam, coachIdParam, userIdByJwt);
-
-		routineService.checkIsMatching(routineListRequest);
+		RoutineListRequest routineListRequest = routineService.confirmIsMatching(userIdParam, coachIdParam,
+			userIdByJwt);
 
 		List<RoutineForListDto> routineList = routineService.getRoutineForList(routineListRequest);
 		return ResponseEntity.ok(routineList);
 	}
 
-	public RoutineListRequest createRoutineListRequest(Long userIdParam, Long coachIdParam, Long userIdByJwt) {
-		if (coachIdParam == null && userIdParam == null) {
-			return new RoutineListRequest(userIdByJwt, null);
-		} else if (coachIdParam == null) {
-			Long coachId = routineService.getCoachId(userIdByJwt);
-			return new RoutineListRequest(userIdParam, coachId);
-		} else {
-			return new RoutineListRequest(userIdByJwt, coachIdParam);
-		}
+	@GetMapping("/v1/routines/user")
+	public ResponseEntity<UserInfoForRoutineList> getUserInfoForRoutineList(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestParam(name = "coachId", required = false) Long coachIdParam,
+		@RequestParam(name = "userId", required = false) Long userIdParam) {
+
+		Long userIdByJwt = userDetails.getUserId();
+		RoutineListRequest routineListRequest = routineService.confirmIsMatching(userIdParam, coachIdParam,
+			userIdByJwt);
+
+		UserInfoForRoutineList userInfoForRoutineList = routineService.getUserInfoForRoutineList(routineListRequest);
+		return ResponseEntity.ok(userInfoForRoutineList);
+
 	}
 
 	@GetMapping("/v1/test")

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -26,8 +26,8 @@ public class RoutineController {
 	@GetMapping("/v1/routines")
 	public ResponseEntity<List<RoutineForListDto>> getRoutineList(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "coachId", required = false) Long coachIdParam,
-		@RequestParam(name = "userId", required = false) Long userIdParam) {
+		@RequestParam(name = "userId", required = false) Long userIdParam,
+		@RequestParam(name = "coachId", required = false) Long coachIdParam) {
 
 		Long userIdByJwt = userDetails.getUserId();
 		RoutineListRequest routineListRequest = routineService.confirmIsMatching(userIdParam, coachIdParam,
@@ -40,16 +40,16 @@ public class RoutineController {
 	@GetMapping("/v1/routines/user")
 	public ResponseEntity<UserInfoForRoutineList> getUserInfoForRoutineList(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "coachId", required = false) Long coachIdParam,
-		@RequestParam(name = "userId", required = false) Long userIdParam) {
+		@RequestParam(name = "userId", required = false) Long userIdParam,
+		@RequestParam(name = "coachId", required = false) Long coachIdParam) {
 
 		Long userIdByJwt = userDetails.getUserId();
-		RoutineListRequest routineListRequest = routineService.confirmIsMatching(userIdParam, coachIdParam,
-			userIdByJwt);
+		routineService.confirmIsMatching(userIdParam, coachIdParam, userIdByJwt);
 
-		UserInfoForRoutineList userInfoForRoutineList = routineService.getUserInfoForRoutineList(routineListRequest);
+		UserInfoForRoutineList userInfoForRoutineList = routineService.getUserInfoForRoutineList(userIdParam,
+			coachIdParam);
+
 		return ResponseEntity.ok(userInfoForRoutineList);
-
 	}
 
 	@GetMapping("/v1/test")

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UserInfoForRoutineList.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UserInfoForRoutineList.java
@@ -8,8 +8,6 @@ import lombok.Builder;
 public record UserInfoForRoutineList(
 	Long userId,
 
-	Long coachId,
-
 	@NotBlank
 	@Size(max = 45)
 	String nickname,

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UserInfoForRoutineList.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UserInfoForRoutineList.java
@@ -5,8 +5,9 @@ import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
-public record RoutineListCoachInfoDto(
-	@NotBlank
+public record UserInfoForRoutineList(
+	Long userId,
+
 	Long coachId,
 
 	@NotBlank
@@ -14,6 +15,7 @@ public record RoutineListCoachInfoDto(
 	String nickname,
 
 	@Size(max = 500)
-	String profileImageUrl) {
+	String profileImageUrl
+) {
 
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/services/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/services/RoutineService.java
@@ -88,7 +88,7 @@ public class RoutineService {
 			User userInfo = coachRepository.findById(coachIdParam)
 				.orElseThrow(() -> new UserNotFoundException(ErrorMessage.NOT_FOUND_COACH))
 				.getUser();
-			return new UserInfoForRoutineList(coachIdParam, userInfo.getNickname(),
+			return new UserInfoForRoutineList(userInfo.getUserId(), userInfo.getNickname(),
 				userInfo.getProfileImageUrl());
 		} else {
 			User userInfo = userRepository.findById(userIdParam)

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/services/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/services/RoutineService.java
@@ -3,6 +3,8 @@ package site.coach_coach.coach_coach_server.routine.services;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import site.coach_coach.coach_coach_server.user.repository.UserRepository;
 @Service
 @RequiredArgsConstructor
 public class RoutineService {
+	private static final Logger log = LoggerFactory.getLogger(RoutineService.class);
 	private final RoutineRepository routineRepository;
 	private final MatchingRepository matchingRepository;
 	private final CoachRepository coachRepository;
@@ -55,9 +58,8 @@ public class RoutineService {
 	}
 
 	public Long getCoachId(Long userIdByJwt) {
-		return userRepository.findById(userIdByJwt)
-			.orElseThrow(() -> new UserNotFoundException(ErrorMessage.NOT_FOUND_COACH))
-			.getCoach().getCoachId();
+		return coachRepository.findCoachIdByUserId(userIdByJwt)
+			.orElseThrow(() -> new UserNotFoundException(ErrorMessage.NOT_FOUND_COACH));
 	}
 
 	public List<RoutineForListDto> getRoutineForList(RoutineListRequest routineListRequest) {

--- a/src/main/java/site/coach_coach/coach_coach_server/user/exception/InvalidUserException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/exception/InvalidUserException.java
@@ -6,6 +6,6 @@ import site.coach_coach.coach_coach_server.common.validation.ErrorMessage;
 
 public class InvalidUserException extends AuthenticationException {
 	public InvalidUserException() {
-		super(ErrorMessage.NOT_FOUND_USER);
+		super(ErrorMessage.INVALID_USER);
 	}
 }

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -55,7 +55,7 @@ public class RoutineControllerTest {
 	public void setUp() {
 		routine = new RoutineForListDto(1L, "routineName", "sportName");
 		routineList = List.of(routine);
-		userInfoForRoutineList = new UserInfoForRoutineList(null, 1L, "nickname", "profileImageUrl");
+		userInfoForRoutineList = new UserInfoForRoutineList(1L, "nickname", "profileImageUrl");
 
 	}
 
@@ -111,7 +111,7 @@ public class RoutineControllerTest {
 		setSecurityContextWithMockUserDetails(userIdByJwt);
 
 		when(routineService.confirmIsMatching(userIdParam, coachIdParam, userIdByJwt)).thenReturn(routineListRequest);
-		when(routineService.getUserInfoForRoutineList(routineListRequest)).thenReturn(userInfoForRoutineList);
+		when(routineService.getUserInfoForRoutineList(userIdParam, coachIdParam)).thenReturn(userInfoForRoutineList);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routines/user"))
 			.andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/site/coach_coach/coach_coach_server/user/controller/UserControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/user/controller/UserControllerTest.java
@@ -246,6 +246,6 @@ public class UserControllerTest {
 			.andExpect(MockMvcResultMatchers.status().isUnauthorized())
 			.andReturn();
 
-		assertThat(result.getResponse().getContentAsString()).contains(ErrorMessage.NOT_FOUND_USER);
+		assertThat(result.getResponse().getContentAsString()).contains(ErrorMessage.INVALID_USER);
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 루틴 목록 관련 사용자 정보 조회 API를 구현하였습니다.
- 일반 회원 입장에서 특정 코치가 만들어준 루틴 목록에 접근할 때, 해당 코치의 정보를 반환합니다.
- 코치가 특정 회원에게 만들어준 루틴 목록에 접근할 때, 해당 회원의 정보를 반환합니다.

### PR Point
- 이전 "루틴 목록 조회 API"에서 분리된 API 입니다.
- "루틴 목록 조회 API"의 Controller에 있던 비즈니스 로직을 Service로 옮겼습니다.
- 코치, 일반회원의 정보는 모두 Users 테이블의 정보이기에 Users 테이블의 컬럼을 사용하였습니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|<img width="477" alt="image" src="https://github.com/user-attachments/assets/229caee7-b956-4f15-b9d1-b90bedd7e8e3">|코치 입장에서 회원의 루틴 목록 조회 시, 회원 정보 응답|
|<img width="475" alt="image" src="https://github.com/user-attachments/assets/7a130bfb-d2b6-48b5-a3b6-8c26ea725166">|일반 회원 입장에서 코치가 만들어준 루틴 목록 조회 시, 코치 정보 응답|
|<img width="473" alt="image" src="https://github.com/user-attachments/assets/5ea217bf-17dc-4e37-8284-b9bef8b577b0">|매칭되지 않은 경우 예외로 처리|

### 논의 사항 (선택)

closed #82
