### PR TITLE
feat(sentry) : 서버 에러 센트리 이슈 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     implementation("com.slack.api:slack-api-client:1.30.0")
+    implementation 'io.sentry:sentry-spring-jakarta:7.14.0'
 }
 
 

--- a/src/main/java/site/coach_coach/coach_coach_server/CoachCoachServerApplication.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/CoachCoachServerApplication.java
@@ -4,12 +4,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+import io.sentry.Sentry;
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class CoachCoachServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(CoachCoachServerApplication.class, args);
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> Sentry.captureMessage(ErrorMessage.SERVER_SHUTDOWN)));
 	}
-
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/JwtExceptionFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/JwtExceptionFilter.java
@@ -12,6 +12,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
+import io.sentry.Sentry;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,10 +34,13 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 		try {
 			filterChain.doFilter(request, response);
 		} catch (ExpiredJwtException e) {
+			Sentry.captureException(e);
 			setErrorResponse(response, ErrorMessage.EXPIRED_TOKEN);
 		} catch (SignatureException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+			Sentry.captureException(e);
 			setErrorResponse(response, ErrorMessage.INVALID_TOKEN);
 		} catch (JwtException e) {
+			Sentry.captureException(e);
 			setErrorResponse(response, ErrorMessage.NOT_FOUND_TOKEN);
 		}
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -35,5 +35,6 @@ public final class ErrorMessage {
 	public static final String NOT_MATCHING = "매칭되지 않은 대상입니다.";
 
 	public static final String NOT_FOUND_SPORTS = "종목 정보가 없습니다.";
+	public static final String SERVER_SHUTDOWN = "서버가 종료되었습니다.";
 }
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
+import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 import site.coach_coach.coach_coach_server.common.response.ErrorResponse;
@@ -29,6 +30,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(HandlerMethodValidationException.class)
 	public ResponseEntity<ErrorResponse> handlerMethodValidationException(HandlerMethodValidationException ex) {
+		Sentry.captureException(ex);
 		String errorMessage = ex.getAllValidationResults()
 			.getFirst()
 			.getResolvableErrors()
@@ -42,6 +44,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+		Sentry.captureException(ex);
 		List<FieldError> fieldErrors = ex.getFieldErrors();
 		String message = fieldErrors.stream()
 			.map(FieldError::getDefaultMessage)
@@ -55,6 +58,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(UserNotFoundException.class)
 	public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException ex) {
+		Sentry.captureException(ex);
 		ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
 		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -63,6 +67,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NoSuchElementException.class)
 	public ResponseEntity<ErrorResponse> handleNoSuchElementException(NoSuchElementException ex) {
+		Sentry.captureException(ex);
 		ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
 
 		return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -71,18 +76,21 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(AuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException ex) {
+		Sentry.captureException(ex);
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
 			.body(new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), ErrorMessage.NOT_FOUND_TOKEN));
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+		Sentry.captureException(ex);
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ErrorMessage.INVALID_VALUE));
 	}
 
 	@ExceptionHandler(UserAlreadyExistException.class)
 	public ResponseEntity<ErrorResponse> handleUserAlreadyExistException(UserAlreadyExistException ex) {
+		Sentry.captureException(ex);
 		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.CONFLICT)
 			.body(new ErrorResponse(HttpStatus.CONFLICT.value(), ex.getMessage()));
@@ -90,6 +98,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(InvalidInputException.class)
 	public ResponseEntity<ErrorResponse> handleInvalidInputException(InvalidInputException ex) {
+		Sentry.captureException(ex);
 		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
@@ -97,6 +106,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(InvalidUserException.class)
 	public ResponseEntity<ErrorResponse> handleInvalidUserException(InvalidUserException ex) {
+		Sentry.captureException(ex);
 		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
 			.body(new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage()));
@@ -104,6 +114,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(IncorrectPasswordException.class)
 	public ResponseEntity<ErrorResponse> handleIncorrectPasswordException(IncorrectPasswordException ex) {
+		Sentry.captureException(ex);
 		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
@@ -111,6 +122,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+		Sentry.captureException(ex);
 		log.error("Unhandled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), ErrorMessage.SERVER_ERROR));

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/SentryConfiguration.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/SentryConfiguration.java
@@ -1,0 +1,10 @@
+package site.coach_coach.coach_coach_server.common.exception;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.sentry.spring.jakarta.EnableSentry;
+
+@EnableSentry
+@Configuration
+class SentryConfiguration {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SentryConfiguration.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SentryConfiguration.java
@@ -1,10 +1,10 @@
-package site.coach_coach.coach_coach_server.common.exception;
+package site.coach_coach.coach_coach_server.config;
 
 import org.springframework.context.annotation.Configuration;
 
 import io.sentry.spring.jakarta.EnableSentry;
 
-@EnableSentry
+@EnableSentry(dsn = "${sentry.dsn}")
 @Configuration
 class SentryConfiguration {
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- Sentry SDK를 프로젝트에 추가하여 에러 및 메시지를 수집하도록 설정했습니다.
- Sentry.captureMessage() 메서드를 사용하여 서버 에러 혹은 종료 시 메시지를 전송하도록 설정했습니다.

### PR Point
- `application.properties`에 slack에 올린 sentry 관련 코드를 추가해주세요.

### 📸 스크린샷

| 사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/aad38aa7-71b1-47eb-bead-77e06988a88f)| 발생한 이슈 sentry 에서 관리 |

### 논의 사항 (선택)
- 서버 관련 알림만 slack으로 가도록 설정했습니다.

closed #67 