### PR TITLE
feature(routine) : 루틴 추가 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/domain/Coach.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/domain/Coach.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 import site.coach_coach.coach_coach_server.common.domain.DateEntity;
 import site.coach_coach.coach_coach_server.sport.domain.CoachingSport;
 import site.coach_coach.coach_coach_server.user.domain.User;
+
 @Entity
 @Table(name = "coaches")
 @Getter
@@ -33,6 +34,7 @@ public class Coach extends DateEntity {
 	@Column(name = "coach_id")
 	private Long coachId;
 
+	@NotNull
 	@OneToOne
 	@JoinColumn(name = "user_Id")
 	private User user;

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDto.java
@@ -3,10 +3,12 @@ package site.coach_coach.coach_coach_server.coach.dto;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import site.coach_coach.coach_coach_server.sport.dto.CoachingSportDto;
 
 public record CoachDto(
+	@NotNull
 	Long coachId,
 	@NotBlank
 	String coachName,
@@ -14,9 +16,9 @@ public record CoachDto(
 	String profileImageUrl,
 	@NotBlank
 	String description,
-	@NotBlank
+	@NotNull
 	int countOfLikes,
-	@NotBlank
+	@NotNull
 	boolean isLiked,
 	List<CoachingSportDto> coachingSports
 ) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDto.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Size;
 import site.coach_coach.coach_coach_server.sport.dto.CoachingSportDto;
 
 public record CoachDto(
-	@NotBlank
 	Long coachId,
 	@NotBlank
 	String coachName,

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -31,8 +31,7 @@ public final class ErrorMessage {
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
-	public static final String INVALID_ID = "유요하지 않은 ID 입니다.";
-	public static final String BLANK_INPUT = "공백일 수 없습니다.";
+	public static final String INVALID_ID = "유효하지 않은 ID 입니다.";
 
 	public static final String NOT_MATCHING = "매칭되지 않은 대상입니다.";
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -31,6 +31,8 @@ public final class ErrorMessage {
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
+	public static final String INVALID_ID = "유요하지 않은 ID 입니다.";
+	public static final String BLANK_INPUT = "공백일 수 없습니다.";
 
 	public static final String NOT_MATCHING = "매칭되지 않은 대상입니다.";
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
@@ -9,7 +9,8 @@ public enum SuccessMessage {
 	LOGOUT_SUCCESS("로그아웃 성공"),
 	EMAIL_AVAILABLE("사용 가능한 이메일입니다."),
 	NICKNAME_AVAILABLE("사용 가능한 닉네임입니다."),
-	PASSWORD_CONFIRM_SUCCESS("비밀번호 확인 성공");
+	PASSWORD_CONFIRM_SUCCESS("비밀번호 확인 성공"),
+	CREATE_ROUTINE_SUCCESS("루틴 추가 성공");
 
 	private final String message;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -6,12 +6,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
+import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
+import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
+import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineListRequest;
 import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
@@ -50,6 +56,19 @@ public class RoutineController {
 			coachIdParam);
 
 		return ResponseEntity.ok(userInfoForRoutineList);
+	}
+
+	@PostMapping("/v1/routines")
+	public ResponseEntity<SuccessResponse> createRoutine(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid CreateRoutineRequest createRoutineRequest
+	) {
+		Long userIdByJwt = userDetails.getUserId();
+		routineService.createRoutine(createRoutineRequest, userIdByJwt);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(
+			new SuccessResponse(HttpStatus.CREATED.value(), SuccessMessage.CREATE_ROUTINE_SUCCESS.getMessage())
+		);
 	}
 
 	@GetMapping("/v1/test")

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -15,9 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
-import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
-import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
+import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineResponse;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineListRequest;
 import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
@@ -39,8 +38,8 @@ public class RoutineController {
 		RoutineListRequest routineListRequest = routineService.confirmIsMatching(userIdParam, coachIdParam,
 			userIdByJwt);
 
-		List<RoutineForListDto> routineList = routineService.getRoutineForList(routineListRequest);
-		return ResponseEntity.ok(routineList);
+		List<RoutineForListDto> routineListResponse = routineService.getRoutineForList(routineListRequest);
+		return ResponseEntity.ok(routineListResponse);
 	}
 
 	@GetMapping("/v1/routines/user")
@@ -59,16 +58,14 @@ public class RoutineController {
 	}
 
 	@PostMapping("/v1/routines")
-	public ResponseEntity<SuccessResponse> createRoutine(
+	public ResponseEntity<CreateRoutineResponse> createRoutine(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestBody @Valid CreateRoutineRequest createRoutineRequest
 	) {
 		Long userIdByJwt = userDetails.getUserId();
-		routineService.createRoutine(createRoutineRequest, userIdByJwt);
-
-		return ResponseEntity.status(HttpStatus.CREATED).body(
-			new SuccessResponse(HttpStatus.CREATED.value(), SuccessMessage.CREATE_ROUTINE_SUCCESS.getMessage())
-		);
+		Long newRoutineId = routineService.createRoutine(createRoutineRequest, userIdByJwt);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(new CreateRoutineResponse(HttpStatus.CREATED.value(), newRoutineId));
 	}
 
 	@GetMapping("/v1/test")

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/domain/Routine.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/domain/Routine.java
@@ -12,37 +12,35 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import site.coach_coach.coach_coach_server.common.domain.DateEntity;
 import site.coach_coach.coach_coach_server.sport.domain.Sport;
 
 @Table(name = "routines")
 @Entity
-@Setter
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Routine extends DateEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@NotBlank
 	@Column(name = "routine_id")
 	private Long routineId;
 
-	@NotBlank
 	@Column(name = "user_id")
 	private Long userId;
 
 	@Column(name = "coach_id")
 	private Long coachId;
 
+	@NotBlank
 	@Size(max = 45)
 	@Column(name = "routine_Name", nullable = false, length = 45)
 	private String routineName;
 
-	@NotBlank
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "sport_id")
 	private Sport sport;

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/domain/Routine.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/domain/Routine.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,17 +30,19 @@ public class Routine extends DateEntity {
 	@Column(name = "routine_id")
 	private Long routineId;
 
+	@NotNull
 	@Column(name = "user_id")
 	private Long userId;
 
 	@Column(name = "coach_id")
 	private Long coachId;
 
-	@NotBlank
+	@NotNull
 	@Size(max = 45)
 	@Column(name = "routine_Name", nullable = false, length = 45)
 	private String routineName;
 
+	@NotNull
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "sport_id")
 	private Sport sport;

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
@@ -1,6 +1,5 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import site.coach_coach.coach_coach_server.routine.validation.RoutineName;
@@ -11,7 +10,7 @@ public record CreateRoutineRequest(
 	@NotNull
 	Long sportId,
 
-	@NotBlank
+	@NotNull
 	@Size(max = 45)
 	@RoutineName
 	String routineName

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
@@ -1,12 +1,14 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import site.coach_coach.coach_coach_server.routine.validation.RoutineName;
 
 public record CreateRoutineRequest(
 	Long userId,
 
+	@NotNull
 	Long sportId,
 
 	@NotBlank

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
@@ -2,19 +2,16 @@ package site.coach_coach.coach_coach_server.routine.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
+import site.coach_coach.coach_coach_server.routine.validation.RoutineName;
 
-@Builder
-public record RoutineForListDto(
-	Long routineId,
+public record CreateRoutineRequest(
+	Long userId,
 
-	@NotBlank
-	@Size(max = 45)
-	String routineName,
+	Long sportId,
 
 	@NotBlank
 	@Size(max = 45)
-	String sportName
+	@RoutineName
+	String routineName
 ) {
-
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineResponse.java
@@ -2,11 +2,11 @@ package site.coach_coach.coach_coach_server.routine.dto;
 
 import jakarta.validation.constraints.NotNull;
 
-public record RoutineListRequest(
+public record CreateRoutineResponse(
 	@NotNull
-	Long userId,
+	int statusCode,
 
-	Long coachId
+	@NotNull
+	Long routineId
 ) {
-
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineForListDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineForListDto.java
@@ -1,11 +1,13 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record RoutineForListDto(
+	@NotNull
 	Long routineId,
 
 	@NotBlank

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineListRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineListRequest.java
@@ -1,12 +1,8 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record RoutineListRequest(
-	@NotBlank
 	Long userId,
 
-	@NotBlank
 	Long coachId
 ) {
 

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UserInfoForRoutineList.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UserInfoForRoutineList.java
@@ -1,11 +1,13 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record UserInfoForRoutineList(
+	@NotNull
 	Long userId,
 
 	@NotBlank

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
@@ -14,11 +14,14 @@ import site.coach_coach.coach_coach_server.common.exception.UserNotFoundExceptio
 import site.coach_coach.coach_coach_server.matching.domain.Matching;
 import site.coach_coach.coach_coach_server.matching.repository.MatchingRepository;
 import site.coach_coach.coach_coach_server.routine.domain.Routine;
+import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineListRequest;
 import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
 import site.coach_coach.coach_coach_server.routine.exception.NotMatchingException;
 import site.coach_coach.coach_coach_server.routine.repository.RoutineRepository;
+import site.coach_coach.coach_coach_server.sport.domain.Sport;
+import site.coach_coach.coach_coach_server.sport.repository.SportRepository;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.repository.UserRepository;
 
@@ -30,6 +33,7 @@ public class RoutineService {
 	private final MatchingRepository matchingRepository;
 	private final CoachRepository coachRepository;
 	private final UserRepository userRepository;
+	private final SportRepository sportRepository;
 
 	public void checkIsMatching(RoutineListRequest routineListRequest) {
 		matchingRepository.findByUserIdAndCoachId(routineListRequest.userId(), routineListRequest.coachId())
@@ -97,6 +101,29 @@ public class RoutineService {
 				.orElseThrow(() -> new UserNotFoundException(ErrorMessage.NOT_FOUND_USER));
 			return new UserInfoForRoutineList(userIdParam, userInfo.getNickname(),
 				userInfo.getProfileImageUrl());
+		}
+	}
+
+	public void createRoutine(CreateRoutineRequest createRoutineRequest, Long userIdByJwt) {
+		Sport sportInfo = Sport.builder()
+			.sportId(createRoutineRequest.sportId())
+			.build();
+
+		if (createRoutineRequest.userId() == null) {
+			Routine newRoutine = Routine.builder()
+				.userId(userIdByJwt)
+				.routineName(createRoutineRequest.routineName())
+				.sport(sportInfo)
+				.build();
+			routineRepository.save(newRoutine);
+		} else {
+			Routine newRoutine = Routine.builder()
+				.userId(createRoutineRequest.userId())
+				.coachId(userIdByJwt)
+				.routineName(createRoutineRequest.routineName())
+				.sport(sportInfo)
+				.build();
+			routineRepository.save(newRoutine);
 		}
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
@@ -3,8 +3,6 @@ package site.coach_coach.coach_coach_server.routine.service;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -21,22 +19,19 @@ import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
 import site.coach_coach.coach_coach_server.routine.exception.NotMatchingException;
 import site.coach_coach.coach_coach_server.routine.repository.RoutineRepository;
 import site.coach_coach.coach_coach_server.sport.domain.Sport;
-import site.coach_coach.coach_coach_server.sport.repository.SportRepository;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 public class RoutineService {
-	private static final Logger log = LoggerFactory.getLogger(RoutineService.class);
 	private final RoutineRepository routineRepository;
 	private final MatchingRepository matchingRepository;
 	private final CoachRepository coachRepository;
 	private final UserRepository userRepository;
-	private final SportRepository sportRepository;
 
-	public void checkIsMatching(RoutineListRequest routineListRequest) {
-		matchingRepository.findByUserIdAndCoachId(routineListRequest.userId(), routineListRequest.coachId())
+	public void checkIsMatching(Long userId, Long coachId) {
+		matchingRepository.findByUserIdAndCoachId(userId, coachId)
 			.map(Matching::getIsMatching)
 			.filter(isMatching -> isMatching) // isMatching이 true일 때만 통과
 			.orElseThrow(() -> new NotMatchingException(ErrorMessage.NOT_MATCHING));
@@ -56,7 +51,7 @@ public class RoutineService {
 			return new RoutineListRequest(userIdByJwt, null);
 		} else {
 			RoutineListRequest request = createRoutineListRequest(userIdParam, coachIdParam, userIdByJwt);
-			checkIsMatching(request);
+			checkIsMatching(request.userId(), request.coachId());
 			return request;
 		}
 	}
@@ -67,26 +62,26 @@ public class RoutineService {
 	}
 
 	public List<RoutineForListDto> getRoutineForList(RoutineListRequest routineListRequest) {
-		List<RoutineForListDto> routineForListDtos = new ArrayList<>();
-		List<Routine> routineList;
+		List<RoutineForListDto> routineListResponse = new ArrayList<>();
+		List<Routine> routines;
 
 		if (routineListRequest.coachId() == null) {
-			routineList = routineRepository.findByUserIdAndCoachIdIsNull(routineListRequest.userId());
+			routines = routineRepository.findByUserIdAndCoachIdIsNull(routineListRequest.userId());
 		} else {
-			routineList = routineRepository.findByUserIdAndCoachId(routineListRequest.userId(),
+			routines = routineRepository.findByUserIdAndCoachId(routineListRequest.userId(),
 				routineListRequest.coachId());
 		}
 
-		routineList.forEach((routine) -> {
+		routines.forEach((routine) -> {
 			RoutineForListDto dto = RoutineForListDto.builder()
 				.routineId(routine.getRoutineId())
 				.routineName(routine.getRoutineName())
 				.sportName(routine.getSport().getSportName())
 				.build();
-			routineForListDtos.add(dto);
+			routineListResponse.add(dto);
 		});
 
-		return routineForListDtos;
+		return routineListResponse;
 	}
 
 	public UserInfoForRoutineList getUserInfoForRoutineList(Long userIdParam, Long coachIdParam) {
@@ -104,26 +99,22 @@ public class RoutineService {
 		}
 	}
 
-	public void createRoutine(CreateRoutineRequest createRoutineRequest, Long userIdByJwt) {
+	public Long createRoutine(CreateRoutineRequest createRoutineRequest, Long userIdByJwt) {
 		Sport sportInfo = Sport.builder()
 			.sportId(createRoutineRequest.sportId())
 			.build();
 
-		if (createRoutineRequest.userId() == null) {
-			Routine newRoutine = Routine.builder()
-				.userId(userIdByJwt)
-				.routineName(createRoutineRequest.routineName())
-				.sport(sportInfo)
-				.build();
-			routineRepository.save(newRoutine);
-		} else {
-			Routine newRoutine = Routine.builder()
-				.userId(createRoutineRequest.userId())
-				.coachId(userIdByJwt)
-				.routineName(createRoutineRequest.routineName())
-				.sport(sportInfo)
-				.build();
-			routineRepository.save(newRoutine);
+		Routine.RoutineBuilder routineBuilder = Routine.builder()
+			.userId(createRoutineRequest.userId() == null ? userIdByJwt : createRoutineRequest.userId())
+			.routineName(createRoutineRequest.routineName())
+			.sport(sportInfo);
+
+		if (createRoutineRequest.userId() != null) {
+			Long coachId = getCoachId(userIdByJwt);
+			checkIsMatching(createRoutineRequest.userId(), coachId);
+			routineBuilder.coachId(coachId);
 		}
+
+		return routineRepository.save(routineBuilder.build()).getRoutineId();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineName.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineName.java
@@ -1,0 +1,23 @@
+package site.coach_coach.coach_coach_server.routine.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+
+@Documented
+@Constraint(validatedBy = RoutineNameValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RoutineName {
+	String message() default ErrorMessage.INVALID_PASSWORD;
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineName.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineName.java
@@ -12,10 +12,10 @@ import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 
 @Documented
 @Constraint(validatedBy = RoutineNameValidator.class)
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RoutineName {
-	String message() default ErrorMessage.INVALID_PASSWORD;
+	String message() default ErrorMessage.INVALID_VALUE;
 
 	Class<?>[] groups() default {};
 

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineNameValidator.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineNameValidator.java
@@ -1,0 +1,23 @@
+package site.coach_coach.coach_coach_server.routine.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+
+public class RoutineNameValidator implements ConstraintValidator<RoutineName, String> {
+	@Override
+	public boolean isValid(String routineName, ConstraintValidatorContext context) {
+		if (routineName.isBlank()) {
+			return addErrorMessage(context, ErrorMessage.BLANK_INPUT);
+		}
+		return true;
+	}
+
+	private boolean addErrorMessage(ConstraintValidatorContext context, String message) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(message)
+			.addConstraintViolation();
+
+		return false;
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineNameValidator.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/validation/RoutineNameValidator.java
@@ -8,7 +8,7 @@ public class RoutineNameValidator implements ConstraintValidator<RoutineName, St
 	@Override
 	public boolean isValid(String routineName, ConstraintValidatorContext context) {
 		if (routineName.isBlank()) {
-			return addErrorMessage(context, ErrorMessage.BLANK_INPUT);
+			return addErrorMessage(context, ErrorMessage.INVALID_VALUE);
 		}
 		return true;
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/sport/domain/Sport.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/sport/domain/Sport.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,10 +29,12 @@ public class Sport extends DateEntity {
 	@Column(name = "sport_id")
 	private Long sportId;
 
+	@NotBlank
 	@Size(max = 45)
 	@Column(name = "sport_name")
 	private String sportName;
 
+	@NotBlank
 	@Size(max = 400)
 	@Column(name = "sport_image_url")
 	private String sportImageUrl;

--- a/src/main/java/site/coach_coach/coach_coach_server/sport/domain/Sport.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/sport/domain/Sport.java
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,12 +28,10 @@ public class Sport extends DateEntity {
 	@Column(name = "sport_id")
 	private Long sportId;
 
-	@NotBlank
 	@Size(max = 45)
 	@Column(name = "sport_name")
 	private String sportName;
 
-	@NotBlank
 	@Size(max = 400)
 	@Column(name = "sport_image_url")
 	private String sportImageUrl;

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,15 +22,20 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import site.coach_coach.coach_coach_server.auth.jwt.TokenFilter;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
+import site.coach_coach.coach_coach_server.config.CustomAuthenticationEntryPoint;
+import site.coach_coach.coach_coach_server.config.SecurityConfig;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineListRequest;
 import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
 import site.coach_coach.coach_coach_server.routine.service.RoutineService;
 
 @WebMvcTest(RoutineController.class)
+@Import({SecurityConfig.class, CustomAuthenticationEntryPoint.class})
 public class RoutineControllerTest {
 
 	@Autowired
@@ -51,9 +57,12 @@ public class RoutineControllerTest {
 	private RoutineForListDto routine;
 	private List<RoutineForListDto> routineList;
 	private UserInfoForRoutineList userInfoForRoutineList;
+	private ObjectMapper objectMapper;
 
 	@BeforeEach
 	public void setUp() {
+		objectMapper = new ObjectMapper();
+
 		routine = new RoutineForListDto(1L, "routineName", "sportName");
 		routineList = List.of(routine);
 		userInfoForRoutineList = new UserInfoForRoutineList(1L, "nickname", "profileImageUrl");

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -2,7 +2,6 @@ package site.coach_coach.coach_coach_server.routine.controller;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,11 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenFilter;
 import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
-import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
-import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
 import site.coach_coach.coach_coach_server.config.CustomAuthenticationEntryPoint;
 import site.coach_coach.coach_coach_server.config.SecurityConfig;
-import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineListRequest;
 import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
@@ -171,49 +166,6 @@ public class RoutineControllerTest {
 
 		assertThat(result.getResponse().getContentAsString().contains(userInfoForRoutineList.nickname()));
 
-	}
-
-	@Test
-	@DisplayName("루틴 추가 성공 테스트")
-	public void createRoutineSuccessTest() throws Exception {
-		// Given
-		Long userIdByJwt = 1L;
-		CreateRoutineRequest createRoutineRequest =
-			new CreateRoutineRequest(2L, 1L, "나의 헬스 루틴");
-
-		setSecurityContextWithMockUserDetails(userIdByJwt);
-
-		doNothing().when(routineService).createRoutine(createRoutineRequest, userIdByJwt);
-
-		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/routines").with(csrf())
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createRoutineRequest)))
-			.andExpect(MockMvcResultMatchers.status().isCreated())
-			.andReturn();
-
-		assertThat(result.getResponse().getContentAsString()).contains(
-			SuccessMessage.CREATE_ROUTINE_SUCCESS.getMessage());
-	}
-
-	@Test
-	@DisplayName("루틴 이름 공란 작성 시 400 상태 코드 반환 및 에러 메세지")
-	public void createdRoutineFailTest() throws Exception {
-		// Given
-		Long userIdByJwt = 1L;
-		CreateRoutineRequest createRoutineRequest =
-			new CreateRoutineRequest(null, 1L, "  ");
-
-		setSecurityContextWithMockUserDetails(userIdByJwt);
-
-		doNothing().when(routineService).createRoutine(createRoutineRequest, userIdByJwt);
-
-		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/routines")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createRoutineRequest)))
-			.andExpect(MockMvcResultMatchers.status().isBadRequest())
-			.andReturn();
-
-		assertThat(result.getResponse().getContentAsString()).contains(ErrorMessage.INVALID_VALUE);
 	}
 
 	public void setSecurityContextWithMockUserDetails(Long userIdByJwt) {


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 루틴 추가 API 구현
- RequestBody의 userId 값에 따라 자신의 루틴을 만들거나, 코치가 매칭된 회원에게 루틴을 만들어 줄 수 있습니다.
- 코치가 일반 회원에게 만들어주는 경우, 매칭 관계에 대한 예외처리를 하였습니다.
- 루틴 이름을 "  " 과 같이 공백(spacebar)으로만 작성한 경우에 대한 예외처리를 하였습니다.

### PR Point
- String 데이터에서 @NotBlank 사용 시, RoutineNameValidator 이전에 기본 검증이 먼저 실행되어 
의도치 않은 message가 출력되었습니다. 
@NotBlank과 @NotNull 사용 시, 주의하시기 바랍니다!

### 📸 스크린샷
|사진|설명|
|---|---|
|<img width="443" alt="image" src="https://github.com/user-attachments/assets/9f0fe4f5-f016-4169-b805-25bda31129c6">|코치 입장에서 매칭된 회원에게 루틴 생성|
|<img width="431" alt="image" src="https://github.com/user-attachments/assets/4a4a45fb-a74d-4345-a8da-a286e46855c5">|회원이 스스로 루틴 생성|
|<img width="416" alt="image" src="https://github.com/user-attachments/assets/e9f3508a-69cb-4a41-9c3d-2daaa584219f">|루틴 이름을 공백으로 입력한 경우 예외 처리|
|<img width="459" alt="image" src="https://github.com/user-attachments/assets/ce1da5df-a55c-4495-a4ed-476b42489b7f">|매칭 관계가 아닌 경우 예외 처리|

### 논의 사항 (선택)
- 작성한 테스트 코드가 통과되지 않아 최신 커밋에는 추가하지 않았습니다.
  Post API 테스트 코드 관련해서 질문이 있으니 다같이 이야기 해보면 좋겠습니다!

closed #60 
