### PR TITLE
feat(routine) : 루틴 삭제 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -28,6 +28,7 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_USER = "존재하지 않는 회원입니다.";
 	public static final String NOT_FOUND_COACH = "존재하지 않는 코치입니다.";
 	public static final String NOT_FOUND_TOKEN = "토큰이 존재하지 않습니다.";
+	public static final String NOT_FOUND_ROUTINE = "존재하지 않는 루틴입니다.";
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -29,6 +29,9 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_COACH = "존재하지 않는 코치입니다.";
 	public static final String NOT_FOUND_TOKEN = "토큰이 존재하지 않습니다.";
 	public static final String NOT_FOUND_ROUTINE = "존재하지 않는 루틴입니다.";
+	public static final String NOT_FOUND_SPORTS = "종목 정보가 없습니다.";
+
+	public static final String NOT_MY_ROUTINE = "자신의 루틴이 아닙니다.";
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
@@ -36,7 +39,6 @@ public final class ErrorMessage {
 
 	public static final String NOT_MATCHING = "매칭되지 않은 대상입니다.";
 
-	public static final String NOT_FOUND_SPORTS = "종목 정보가 없습니다.";
 	public static final String SERVER_SHUTDOWN = "서버가 종료되었습니다.";
 }
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -31,7 +31,7 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_ROUTINE = "존재하지 않는 루틴입니다.";
 	public static final String NOT_FOUND_SPORTS = "종목 정보가 없습니다.";
 
-	public static final String NOT_MY_ROUTINE = "자신의 루틴이 아닙니다.";
+	public static final String NOT_MY_ROUTINE = "접근 권한이 없습니다.";
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
@@ -10,7 +10,8 @@ public enum SuccessMessage {
 	EMAIL_AVAILABLE("사용 가능한 이메일입니다."),
 	NICKNAME_AVAILABLE("사용 가능한 닉네임입니다."),
 	PASSWORD_CONFIRM_SUCCESS("비밀번호 확인 성공"),
-	CREATE_ROUTINE_SUCCESS("루틴 추가 성공");
+	CREATE_ROUTINE_SUCCESS("루틴 추가 성공"),
+	DELETE_ROUTINE_SUCCESS("루틴 삭제 성공");
 
 	private final String message;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
+import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
+import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
 import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineResponse;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
@@ -66,6 +70,18 @@ public class RoutineController {
 		Long newRoutineId = routineService.createRoutine(createRoutineRequest, userIdByJwt);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(new CreateRoutineResponse(HttpStatus.CREATED.value(), newRoutineId));
+	}
+
+	@DeleteMapping("/v1/routines/{routineId}")
+	public ResponseEntity<SuccessResponse> deleteRoutine(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable(name = "routineId") @Valid Long routineId
+	) {
+		Long userIdByJwt = userDetails.getUserId();
+		routineService.checkIsExistRoutine(routineId);
+		routineService.deleteRoutineWithValidation(routineId, userIdByJwt);
+		return ResponseEntity.ok(
+			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_ROUTINE_SUCCESS.getMessage()));
 	}
 
 	@GetMapping("/v1/test")

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -78,8 +78,7 @@ public class RoutineController {
 		@PathVariable(name = "routineId") @Valid Long routineId
 	) {
 		Long userIdByJwt = userDetails.getUserId();
-		routineService.validateRoutineAccess(routineId, userIdByJwt);
-		routineService.deleteRoutine(routineId);
+		routineService.validateRoutineDelete(routineId, userIdByJwt);
 		return ResponseEntity.ok(
 			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_ROUTINE_SUCCESS.getMessage()));
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -78,7 +78,6 @@ public class RoutineController {
 		@PathVariable(name = "routineId") @Valid Long routineId
 	) {
 		Long userIdByJwt = userDetails.getUserId();
-		routineService.checkIsExistRoutine(routineId);
 		routineService.deleteRoutineWithValidation(routineId, userIdByJwt);
 		return ResponseEntity.ok(
 			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_ROUTINE_SUCCESS.getMessage()));

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -78,7 +78,8 @@ public class RoutineController {
 		@PathVariable(name = "routineId") @Valid Long routineId
 	) {
 		Long userIdByJwt = userDetails.getUserId();
-		routineService.deleteRoutineWithValidation(routineId, userIdByJwt);
+		routineService.validateRoutineAccess(routineId, userIdByJwt);
+		routineService.deleteRoutine(routineId);
 		return ResponseEntity.ok(
 			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_ROUTINE_SUCCESS.getMessage()));
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/exception/NoExistRoutineException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/exception/NoExistRoutineException.java
@@ -1,0 +1,9 @@
+package site.coach_coach.coach_coach_server.routine.exception;
+
+import java.util.NoSuchElementException;
+
+public class NoExistRoutineException extends NoSuchElementException {
+	public NoExistRoutineException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/repository/RoutineRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/repository/RoutineRepository.java
@@ -12,8 +12,4 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 	List<Routine> findByUserIdAndCoachIdIsNull(Long userId);
 
 	List<Routine> findByUserIdAndCoachId(Long userId, Long coachId);
-
-	Boolean existsByRoutineIdAndUserId(Long routineId, Long userIdByJwt);
-
-	Boolean existsByRoutineIdAndCoachId(Long routineId, Long coachId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/repository/RoutineRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/repository/RoutineRepository.java
@@ -12,4 +12,8 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 	List<Routine> findByUserIdAndCoachIdIsNull(Long userId);
 
 	List<Routine> findByUserIdAndCoachId(Long userId, Long coachId);
+
+	Boolean existsByRoutineIdAndUserId(Long routineId, Long userIdByJwt);
+
+	Boolean existsByRoutineIdAndCoachId(Long routineId, Long coachId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
@@ -16,6 +16,7 @@ import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineListRequest;
 import site.coach_coach.coach_coach_server.routine.dto.UserInfoForRoutineList;
+import site.coach_coach.coach_coach_server.routine.exception.NoExistRoutineException;
 import site.coach_coach.coach_coach_server.routine.exception.NotMatchingException;
 import site.coach_coach.coach_coach_server.routine.repository.RoutineRepository;
 import site.coach_coach.coach_coach_server.sport.domain.Sport;
@@ -116,5 +117,21 @@ public class RoutineService {
 		}
 
 		return routineRepository.save(routineBuilder.build()).getRoutineId();
+	}
+
+	public void checkIsExistRoutine(Long routineId) {
+		if (!routineRepository.existsById(routineId)) {
+			throw new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE);
+		}
+	}
+
+	public void deleteRoutineWithValidation(Long routineId, Long userIdByJwt) {
+		if (!routineRepository.existsByRoutineIdAndUserId(routineId, userIdByJwt)) {
+			Long coachId = getCoachId(userIdByJwt);
+			if (!routineRepository.existsByRoutineIdAndCoachId(routineId, coachId)) {
+				throw new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE);
+			}
+		}
+		routineRepository.deleteById(routineId);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
@@ -119,7 +119,11 @@ public class RoutineService {
 		return routineRepository.save(routineBuilder.build()).getRoutineId();
 	}
 
-	public void deleteRoutineWithValidation(Long routineId, Long userIdByJwt) {
+	public void deleteRoutine(Long routineId) {
+		routineRepository.deleteById(routineId);
+	}
+
+	public void validateRoutineAccess(Long routineId, Long userIdByJwt) {
 		Routine routine = routineRepository.findById(routineId)
 			.orElseThrow(() -> new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE));
 
@@ -133,7 +137,5 @@ public class RoutineService {
 				throw new NoExistRoutineException(ErrorMessage.NOT_MY_ROUTINE);
 			}
 		}
-
-		routineRepository.deleteById(routineId);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
@@ -119,11 +119,7 @@ public class RoutineService {
 		return routineRepository.save(routineBuilder.build()).getRoutineId();
 	}
 
-	public void deleteRoutine(Long routineId) {
-		routineRepository.deleteById(routineId);
-	}
-
-	public void validateRoutineAccess(Long routineId, Long userIdByJwt) {
+	public void validateRoutineDelete(Long routineId, Long userIdByJwt) {
 		Routine routine = routineRepository.findById(routineId)
 			.orElseThrow(() -> new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE));
 
@@ -137,5 +133,7 @@ public class RoutineService {
 				throw new NoExistRoutineException(ErrorMessage.NOT_MY_ROUTINE);
 			}
 		}
+
+		routineRepository.deleteById(routineId);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
@@ -119,19 +119,21 @@ public class RoutineService {
 		return routineRepository.save(routineBuilder.build()).getRoutineId();
 	}
 
-	public void checkIsExistRoutine(Long routineId) {
-		if (!routineRepository.existsById(routineId)) {
-			throw new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE);
-		}
-	}
-
 	public void deleteRoutineWithValidation(Long routineId, Long userIdByJwt) {
-		if (!routineRepository.existsByRoutineIdAndUserId(routineId, userIdByJwt)) {
+		Routine routine = routineRepository.findById(routineId)
+			.orElseThrow(() -> new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE));
+
+		if (routine.getCoachId() == null) {
+			if (!routine.getUserId().equals(userIdByJwt)) {
+				throw new NoExistRoutineException(ErrorMessage.NOT_MY_ROUTINE);
+			}
+		} else {
 			Long coachId = getCoachId(userIdByJwt);
-			if (!routineRepository.existsByRoutineIdAndCoachId(routineId, coachId)) {
-				throw new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE);
+			if (!routine.getCoachId().equals(coachId)) {
+				throw new NoExistRoutineException(ErrorMessage.NOT_MY_ROUTINE);
 			}
 		}
+
 		routineRepository.deleteById(routineId);
 	}
 }

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -188,7 +188,7 @@ public class RoutineControllerTest {
 	@Test
 	@DisplayName("루틴 삭제 성공 테스트")
 	public void deleteRoutineSuccessTest() throws Exception {
-		doNothing().when(routineService).checkIsExistRoutine(routine.routineId());
+
 		doNothing().when(routineService).deleteRoutineWithValidation(1L, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/1").with(csrf()))
@@ -205,7 +205,7 @@ public class RoutineControllerTest {
 		// Given
 		Long routineId = 0L;
 		doThrow(new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE)).when(routineService)
-			.checkIsExistRoutine(anyLong());
+			.deleteRoutineWithValidation(anyLong(), anyLong());
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isNotFound())
@@ -220,8 +220,8 @@ public class RoutineControllerTest {
 	public void deleteRoutineFailTest() throws Exception {
 		// Given
 		Long routineId = 0L;
-		doNothing().when(routineService).checkIsExistRoutine(anyLong());
-		doThrow(new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE)).when(routineService)
+
+		doThrow(new NoExistRoutineException(ErrorMessage.NOT_MY_ROUTINE)).when(routineService)
 			.deleteRoutineWithValidation(routineId, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
@@ -229,7 +229,7 @@ public class RoutineControllerTest {
 			.andReturn();
 
 		assertThat(result.getResponse().getContentAsString()).contains(
-			ErrorMessage.NOT_FOUND_ROUTINE);
+			ErrorMessage.NOT_MY_ROUTINE);
 	}
 
 	public void setSecurityContextWithMockUserDetails(Long userIdByJwt) {

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -189,7 +189,7 @@ public class RoutineControllerTest {
 	@DisplayName("루틴 삭제 성공 테스트")
 	public void deleteRoutineSuccessTest() throws Exception {
 
-		doNothing().when(routineService).deleteRoutineWithValidation(1L, userIdByJwt);
+		doNothing().when(routineService).validateRoutineAccess(1L, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/1").with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isOk())
@@ -205,7 +205,7 @@ public class RoutineControllerTest {
 		// Given
 		Long routineId = 0L;
 		doThrow(new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE)).when(routineService)
-			.deleteRoutineWithValidation(anyLong(), anyLong());
+			.validateRoutineAccess(anyLong(), anyLong());
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isNotFound())
@@ -222,7 +222,7 @@ public class RoutineControllerTest {
 		Long routineId = 0L;
 
 		doThrow(new NoExistRoutineException(ErrorMessage.NOT_MY_ROUTINE)).when(routineService)
-			.deleteRoutineWithValidation(routineId, userIdByJwt);
+			.validateRoutineAccess(routineId, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isNotFound())

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -189,7 +189,7 @@ public class RoutineControllerTest {
 	@DisplayName("루틴 삭제 성공 테스트")
 	public void deleteRoutineSuccessTest() throws Exception {
 
-		doNothing().when(routineService).validateRoutineAccess(1L, userIdByJwt);
+		doNothing().when(routineService).validateRoutineDelete(1L, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/1").with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isOk())
@@ -205,7 +205,7 @@ public class RoutineControllerTest {
 		// Given
 		Long routineId = 0L;
 		doThrow(new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE)).when(routineService)
-			.validateRoutineAccess(anyLong(), anyLong());
+			.validateRoutineDelete(anyLong(), anyLong());
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isNotFound())
@@ -222,7 +222,7 @@ public class RoutineControllerTest {
 		Long routineId = 0L;
 
 		doThrow(new NoExistRoutineException(ErrorMessage.NOT_MY_ROUTINE)).when(routineService)
-			.validateRoutineAccess(routineId, userIdByJwt);
+			.validateRoutineDelete(routineId, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isNotFound())


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 루틴 삭제 API를 구현하였습니다.
- 일반 회원은 자신이 만든 루틴을 삭제할 수 있습니다.
- 코치는 매칭된 회원에게 만들어준 루틴을 삭제할 수 있습니다.

### PR Point
- 일반회원이 코치가 만든 루틴에 접근 시, 두 가지 검증을 합니다.
  1. 코치인지 확인
  2. 삭제할 루틴의 coachId와 접근자의 coachId 비교
### 📸 스크린샷
|사진|설명|
|---|---|
|<img width="478" alt="image" src="https://github.com/user-attachments/assets/b5ab75c5-af03-49c4-8186-878a04568e6c">|일반 회원이 자신이 만든 루틴 삭제|
|<img width="455" alt="image" src="https://github.com/user-attachments/assets/cd8a590d-76c4-4bca-9623-438a5dce8486">|코치가 회원에게 만들어준 루틴 삭제|
|<img width="453" alt="image" src="https://github.com/user-attachments/assets/cc09a4b1-672d-4937-b862-7f10f73d42f5">|존재하지 않는 루틴 삭제 예외 처리|
|<img width="445" alt="image" src="https://github.com/user-attachments/assets/06e32e40-fe58-4fb1-80b2-00a4c9b1455c">|코치 또는 일반 회원이 자신이 만들지 않은 루틴 삭제 예외 처리|
|<img width="454" alt="image" src="https://github.com/user-attachments/assets/a0bce9e7-6b1d-4119-ab40-40d2ca9d9a34">|일반 회원이 코치가 만든 루틴 삭제 접근 시 예외 처리 1 - 코치 활동을 하지않는 일반 회원|
|<img width="468" alt="image" src="https://github.com/user-attachments/assets/cdd0e30b-7537-49a7-b6ec-5f16e2e7bb81">|일반 회원이 코치가 만든 루틴 삭제 접근 시 예외 처리 2 - 코치 활동도 겸하는 일반 회원|


### 논의 사항 (선택)

closed #107
