### PR TITLE
fea(notification) : 전체 알림 리스트 조회 api 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -60,7 +60,8 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
 		+ "GROUP BY c.coachId "
 		+ "ORDER BY c.updatedAt DESC")
-	Page<Coach> findMyCoaches(Long userId,
+	Page<Coach> findMyCoaches(
+		@Param("userId") Long userId,
 		@Param("sports") List<Long> sports,
 		@Param("search") String search,
 		Pageable pageable);

--- a/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
@@ -1,0 +1,5 @@
+package site.coach_coach.coach_coach_server.common.domain;
+
+public enum RelationFunctionEnum {
+	review, ask, like
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
@@ -1,0 +1,28 @@
+package site.coach_coach.coach_coach_server.notification.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
+import site.coach_coach.coach_coach_server.notification.dto.NotificationResponse;
+import site.coach_coach.coach_coach_server.notification.service.NotificationService;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class NotificationController {
+	private final NotificationService notificationService;
+
+	@GetMapping("/v1/notifications")
+	public ResponseEntity<List<NotificationResponse>> getAllNotification(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		Long userId = userDetails.getUserId();
+		return ResponseEntity.ok(notificationService.getAllNotifications(userId));
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
-import site.coach_coach.coach_coach_server.notification.dto.NotificationResponse;
+import site.coach_coach.coach_coach_server.notification.dto.NotificationListResponse;
 import site.coach_coach.coach_coach_server.notification.service.NotificationService;
 
 @RestController
@@ -20,10 +20,10 @@ public class NotificationController {
 	private final NotificationService notificationService;
 
 	@GetMapping("/v1/notifications")
-	public ResponseEntity<List<NotificationResponse>> getAllNotifications(
+	public ResponseEntity<List<NotificationListResponse>> getAllNotifications(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		Long userId = userDetails.getUserId();
-		List<NotificationResponse> notifications = notificationService.getAllNotifications(userId);
+		List<NotificationListResponse> notifications = notificationService.getAllNotifications(userId);
 		return ResponseEntity.ok(notifications);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
@@ -23,6 +23,7 @@ public class NotificationController {
 	public ResponseEntity<List<NotificationResponse>> getAllNotification(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		Long userId = userDetails.getUserId();
-		return ResponseEntity.ok(notificationService.getAllNotifications(userId));
+		List<NotificationResponse> notifications = notificationService.getAllNotifications(userId);
+		return ResponseEntity.ok(notifications);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
@@ -20,7 +20,7 @@ public class NotificationController {
 	private final NotificationService notificationService;
 
 	@GetMapping("/v1/notifications")
-	public ResponseEntity<List<NotificationResponse>> getAllNotification(
+	public ResponseEntity<List<NotificationResponse>> getAllNotifications(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		Long userId = userDetails.getUserId();
 		List<NotificationResponse> notifications = notificationService.getAllNotifications(userId);

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/domain/Notification.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/domain/Notification.java
@@ -1,9 +1,5 @@
 package site.coach_coach.coach_coach_server.notification.domain;
 
-import java.time.LocalDateTime;
-
-import org.hibernate.annotations.CreationTimestamp;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -22,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.coach_coach.coach_coach_server.common.domain.DateEntity;
 import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
 import site.coach_coach.coach_coach_server.user.domain.User;
 
@@ -31,7 +28,7 @@ import site.coach_coach.coach_coach_server.user.domain.User;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Notification {
+public class Notification extends DateEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "notification_id")
@@ -51,8 +48,4 @@ public class Notification {
 	@Column(name = "relation_function")
 	@Enumerated(EnumType.STRING)
 	private RelationFunctionEnum relationFunction;
-
-	@CreationTimestamp
-	@Column(name = "created_at")
-	private LocalDateTime createdAt;
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/domain/Notification.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/domain/Notification.java
@@ -40,7 +40,7 @@ public class Notification extends DateEntity {
 	private User user;
 
 	@NotBlank
-	@Column(name = "message")
+	@Column(name = "message", nullable = false, length = 100)
 	@Size(max = 100)
 	private String message;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/domain/Notification.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/domain/Notification.java
@@ -1,0 +1,58 @@
+package site.coach_coach.coach_coach_server.notification.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
+import site.coach_coach.coach_coach_server.user.domain.User;
+
+@Table(name = "notifications")
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long notificationId;
+
+	@NotNull
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@NotBlank
+	@Column(name = "message")
+	@Size(max = 100)
+	private String message;
+
+	@NotNull
+	@Column(name = "relation_function")
+	@Enumerated(EnumType.STRING)
+	private RelationFunctionEnum relationFunction;
+
+	@CreationTimestamp
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationListResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationListResponse.java
@@ -7,14 +7,14 @@ import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
 import site.coach_coach.coach_coach_server.notification.domain.Notification;
 
 @Builder
-public record NotificationResponse(
+public record NotificationListResponse(
 	Long notificationId,
 	String message,
 	RelationFunctionEnum relationFunction,
 	LocalDateTime createdAt
 ) {
-	public static NotificationResponse from(Notification notification) {
-		return new NotificationResponse(
+	public static NotificationListResponse from(Notification notification) {
+		return new NotificationListResponse(
 			notification.getNotificationId(),
 			notification.getMessage(),
 			notification.getRelationFunction(),

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationResponse.java
@@ -2,12 +2,23 @@ package site.coach_coach.coach_coach_server.notification.dto;
 
 import java.time.LocalDateTime;
 
+import lombok.Builder;
 import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
+import site.coach_coach.coach_coach_server.notification.domain.Notification;
 
+@Builder
 public record NotificationResponse(
 	Long notificationId,
 	String message,
 	RelationFunctionEnum relationFunction,
 	LocalDateTime createdAt
 ) {
+	public static NotificationResponse from(Notification notification) {
+		return NotificationResponse.builder()
+			.notificationId(notification.getNotificationId())
+			.message(notification.getMessage())
+			.relationFunction(notification.getRelationFunction())
+			.createdAt(notification.getCreatedAt())
+			.build();
+	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationResponse.java
@@ -14,11 +14,11 @@ public record NotificationResponse(
 	LocalDateTime createdAt
 ) {
 	public static NotificationResponse from(Notification notification) {
-		return NotificationResponse.builder()
-			.notificationId(notification.getNotificationId())
-			.message(notification.getMessage())
-			.relationFunction(notification.getRelationFunction())
-			.createdAt(notification.getCreatedAt())
-			.build();
+		return new NotificationResponse(
+			notification.getNotificationId(),
+			notification.getMessage(),
+			notification.getRelationFunction(),
+			notification.getCreatedAt()
+		);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/dto/NotificationResponse.java
@@ -1,0 +1,13 @@
+package site.coach_coach.coach_coach_server.notification.dto;
+
+import java.time.LocalDateTime;
+
+import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
+
+public record NotificationResponse(
+	Long notificationId,
+	String message,
+	RelationFunctionEnum relationFunction,
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/repository/NotificationRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/repository/NotificationRepository.java
@@ -1,8 +1,11 @@
 package site.coach_coach.coach_coach_server.notification.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import site.coach_coach.coach_coach_server.notification.domain.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+	Optional<Notification> findByUserId(Long userId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/repository/NotificationRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package site.coach_coach.coach_coach_server.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import site.coach_coach.coach_coach_server.notification.domain.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/repository/NotificationRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/repository/NotificationRepository.java
@@ -1,11 +1,11 @@
 package site.coach_coach.coach_coach_server.notification.repository;
 
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import site.coach_coach.coach_coach_server.notification.domain.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-	Optional<Notification> findByUserId(Long userId);
+	List<Notification> findByUser_UserId(Long userId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import site.coach_coach.coach_coach_server.notification.dto.NotificationResponse;
+import site.coach_coach.coach_coach_server.notification.dto.NotificationListResponse;
 import site.coach_coach.coach_coach_server.notification.repository.NotificationRepository;
 import site.coach_coach.coach_coach_server.user.exception.InvalidUserException;
 import site.coach_coach.coach_coach_server.user.repository.UserRepository;
@@ -19,11 +19,14 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 
 	@Transactional(readOnly = true)
-	public List<NotificationResponse> getAllNotifications(Long userId) {
-		userRepository.findById(userId).orElseThrow(InvalidUserException::new);
+	public List<NotificationListResponse> getAllNotifications(Long userId) {
+		boolean userExists = userRepository.existsById(userId);
+		if (!userExists) {
+			throw new InvalidUserException();
+		}
 		return notificationRepository.findByUser_UserId(userId)
 			.stream()
-			.map(NotificationResponse::from)
+			.map(NotificationListResponse::from)
 			.toList();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -18,6 +18,7 @@ public class NotificationService {
 	private final UserRepository userRepository;
 	private final NotificationRepository notificationRepository;
 
+	@Transactional(readOnly = true)
 	public List<NotificationResponse> getAllNotifications(Long userId) {
 		userRepository.findById(userId).orElseThrow(InvalidUserException::new);
 		return notificationRepository.findByUser_UserId(userId)

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -20,7 +20,7 @@ public class NotificationService {
 
 	public List<NotificationResponse> getAllNotifications(Long userId) {
 		userRepository.findById(userId).orElseThrow(InvalidUserException::new);
-		return notificationRepository.findByUserId(userId)
+		return notificationRepository.findByUser_UserId(userId)
 			.stream()
 			.map(NotificationResponse::from)
 			.toList();

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -1,0 +1,12 @@
+package site.coach_coach.coach_coach_server.notification.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -1,12 +1,28 @@
 package site.coach_coach.coach_coach_server.notification.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.coach_coach.coach_coach_server.notification.dto.NotificationResponse;
+import site.coach_coach.coach_coach_server.notification.repository.NotificationRepository;
+import site.coach_coach.coach_coach_server.user.exception.InvalidUserException;
+import site.coach_coach.coach_coach_server.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class NotificationService {
+	private final UserRepository userRepository;
+	private final NotificationRepository notificationRepository;
+
+	public List<NotificationResponse> getAllNotifications(Long userId) {
+		userRepository.findById(userId).orElseThrow(InvalidUserException::new);
+		return notificationRepository.findByUserId(userId)
+			.stream()
+			.map(NotificationResponse::from)
+			.toList();
+	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/user/domain/User.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/user/domain/User.java
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
 import site.coach_coach.coach_coach_server.coach.domain.Coach;
 import site.coach_coach.coach_coach_server.common.domain.DateEntity;
 import site.coach_coach.coach_coach_server.common.domain.GenderEnum;
+import site.coach_coach.coach_coach_server.notification.domain.Notification;
 import site.coach_coach.coach_coach_server.sport.domain.InterestedSport;
 
 @Table(name = "users")
@@ -79,6 +80,9 @@ public class User extends DateEntity {
 
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private List<InterestedSport> interestedSports;
+
+	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+	private List<Notification> notifications;
 
 	public void updateProfile(String nickname, String profileImageUrl, GenderEnum gender, String localAddress,
 		String localAddressDetail, String introduction, List<InterestedSport> interestedSports) {

--- a/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/auth/jwt/TokenProviderTest.java
@@ -45,7 +45,7 @@ public class TokenProviderTest {
 			faker.name().firstName(),
 			faker.internet().emailAddress(),
 			"test1234!",
-			null, null, null, null, null, null, null
+			null, null, null, null, null, null, null, null
 		);
 		tokenProvider = new TokenProvider(jwtProperties, customUserDetailsService);
 	}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- `Notification` 엔티티를 정의하, 알림의 기본 속성과 관계를 설정했습니다.
- 알림 데이터를 반환할 때 사용하는 `NotificationResponse` DTO를 생성하였습니다.
- `NotificationRepository`에서 사용자 ID를 기준으로 알림을 조회합니다.
- `NotificationService` 클래스에서 알림을 조회하고 `NotificationResponse`로 변환합니다.
- `NotificationController`를 구현하여 사용자 ID를 기반으로 알림 목록을 반환하는 API를 작성했습니다.

### PR Point
- 유저가 존재하지 않을 경우 예외를 던지고, 알림을 올바르게 조회 및 변환하는 로직이 잘 구현되었는지 검토해주세요.
- createdAt은 프론트와 상의하여 formatting하는 util 함수를 추후에 생성하려고 합니다!

### 📸 스크린샷
| 사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/055c03fa-3e37-41e3-b9bb-d61036f44996)| 조회 시 |


closed #116 
