### PR TITLE
refactor(reissue) : access token 재발급 api 로직 수정 

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
@@ -26,7 +26,6 @@ public class TokenFilter extends OncePerRequestFilter {
 		response.setCharacterEncoding("utf-8");
 
 		String accessToken = tokenProvider.getCookieValue(request, ACCESS_TOKEN);
-		
 		if (accessToken == null) {
 			filterChain.doFilter(request, response);
 			return;

--- a/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/auth/jwt/TokenFilter.java
@@ -25,15 +25,12 @@ public class TokenFilter extends OncePerRequestFilter {
 		throws ServletException, IOException {
 		response.setCharacterEncoding("utf-8");
 
-		String requestUri = request.getRequestURI();
-		if (requestUri.equals("/api/v1/auth/login") || requestUri.equals("/api/v1/auth/signup") || requestUri.equals(
-			"/api/v1/test") || requestUri.equals("/api/v1/auth/check-email") || requestUri.equals(
-			"/api/v1/auth/check-nickname")) {
+		String accessToken = tokenProvider.getCookieValue(request, ACCESS_TOKEN);
+		
+		if (accessToken == null) {
 			filterChain.doFilter(request, response);
 			return;
 		}
-
-		String accessToken = tokenProvider.getCookieValue(request, ACCESS_TOKEN);
 
 		if (tokenProvider.validateAccessToken(accessToken)) {
 			Authentication authentication = tokenProvider.getAuthentication(accessToken);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -60,7 +60,8 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
 		+ "GROUP BY c.coachId "
 		+ "ORDER BY c.updatedAt DESC")
-	Page<Coach> findMyCoaches(Long userId,
+	Page<Coach> findMyCoaches(
+		@Param("userId") Long userId,
 		@Param("sports") List<Long> sports,
 		@Param("search") String search,
 		Pageable pageable);

--- a/src/main/java/site/coach_coach/coach_coach_server/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/CustomAuthenticationEntryPoint.java
@@ -10,9 +10,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 import site.coach_coach.coach_coach_server.common.response.ErrorResponse;
 
+@Slf4j
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 	private final ObjectMapper objectMapper = new ObjectMapper();
@@ -20,6 +22,11 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException authException) throws IOException {
+
+		log.error("Unauthorized request - Method: {}, URI: {}, Error: {}",
+			request.getMethod(),
+			request.getRequestURI(),
+			authException.getMessage());
 
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json");

--- a/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests((authorizeRequests) ->
 				authorizeRequests
 					.requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/test",
-						"/api/v1/auth/check-email", "/api/v1/auth/check-nickname")
+						"/api/v1/auth/check-email", "/api/v1/auth/check-nickname", "/api/v1/auth/reissue")
 					.permitAll()
 					.anyRequest()
 					.authenticated()


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- security config와 tokenfilter에서 여러 번 검증하는 부분을 수정하였습니다.
- 재발급 api는 accessToken토큰 검증을 건너뜁니다.

### PR Point
- access token이 null 일 경우는 accesstoken 검증이 필요없는 url이므로 건너뜁니다.
- 재발급 api의 경우 refresh token을 validate하여 accesstoken을 재발급하므로 security config에 url 추가해줬습니다.
- 만약 refresh token cookie가 없는 경우 에러가 발생합니다. 
- 재발급 api 호출 시 access token이 재발급되는지 확인해주세요! 


closed #128 
