### PR TITLE
feat(coach) : Contact coach API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -1,8 +1,11 @@
 package site.coach_coach.coach_coach_server.coach.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,6 +14,8 @@ import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.coach.dto.CoachDetailDto;
 import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
+import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
+import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.exception.InvalidUserException;
 
@@ -57,4 +62,14 @@ public class CoachController {
 		return ResponseEntity.ok(response);
 	}
 
+	@PostMapping("/v1/coaches/{coachId}/contact")
+	public ResponseEntity<SuccessResponse> contactCoach(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable Long coachId
+	) {
+		User user = userDetails.getUser();
+		coachService.contactCoach(user, coachId);
+		return ResponseEntity.ok(
+			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.CREATE_CONTACT_SUCCESS.getMessage()));
+	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -13,8 +13,9 @@ import org.springframework.web.bind.annotation.RestController;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.coach.dto.CoachDetailDto;
 import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
-import site.coach_coach.coach_coach_server.coach.dto.CreateContactResponse;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
+import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
+import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.exception.InvalidUserException;
 
@@ -62,14 +63,13 @@ public class CoachController {
 	}
 
 	@PostMapping("/v1/coaches/{coachId}/contact")
-	public ResponseEntity<CreateContactResponse> contactCoach(
+	public ResponseEntity<SuccessResponse> contactCoach(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable Long coachId
 	) {
 		User user = userDetails.getUser();
-		Long matchingId = coachService.contactCoach(user, coachId);
-
-		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(new CreateContactResponse(HttpStatus.CREATED.value(), matchingId));
+		coachService.contactCoach(user, coachId);
+		return ResponseEntity.ok(
+			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.CREATE_CONTACT_SUCCESS.getMessage()));
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -13,9 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.coach.dto.CoachDetailDto;
 import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
+import site.coach_coach.coach_coach_server.coach.dto.CreateContactResponse;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
-import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
-import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.exception.InvalidUserException;
 
@@ -63,13 +62,14 @@ public class CoachController {
 	}
 
 	@PostMapping("/v1/coaches/{coachId}/contact")
-	public ResponseEntity<SuccessResponse> contactCoach(
+	public ResponseEntity<CreateContactResponse> contactCoach(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable Long coachId
 	) {
 		User user = userDetails.getUser();
-		coachService.contactCoach(user, coachId);
-		return ResponseEntity.ok(
-			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.CREATE_CONTACT_SUCCESS.getMessage()));
+		Long matchingId = coachService.contactCoach(user, coachId);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(new CreateContactResponse(HttpStatus.CREATED.value(), matchingId));
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CreateContactResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CreateContactResponse.java
@@ -1,0 +1,12 @@
+package site.coach_coach.coach_coach_server.coach.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateContactResponse(
+	@NotNull
+	int statusCode,
+
+	@NotNull
+	Long matchingId
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/exception/DuplicateContactException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/exception/DuplicateContactException.java
@@ -1,0 +1,11 @@
+package site.coach_coach.coach_coach_server.coach.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class DuplicateContactException extends RuntimeException {
+	public DuplicateContactException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -160,15 +160,16 @@ public class CoachService {
 		return new CoachListResponse(coaches, (int)coachesPage.getTotalElements(), page);
 	}
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public void contactCoach(User user, Long coachId) {
-		Long userId = user.getUserId();
-		coachRepository.findById(coachId).orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
+		Coach coach = coachRepository.findById(coachId)
+			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
 
-		Optional<Matching> existingMatchingOpt = matchingRepository.findByUserIdAndCoachId(userId, coachId);
+		Optional<Matching> existingMatchingOpt = matchingRepository.findByUserUserIdAndCoachCoachId(user.getUserId(),
+			coachId);
 
 		if (existingMatchingOpt.isEmpty()) {
-			Matching newMatching = new Matching(null, userId, coachId, false);
+			Matching newMatching = new Matching(null, user, coach, false);
 			matchingRepository.save(newMatching);
 		}
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -23,6 +23,8 @@ import site.coach_coach.coach_coach_server.coach.exception.NotFoundSportExceptio
 import site.coach_coach.coach_coach_server.coach.repository.CoachRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 import site.coach_coach.coach_coach_server.like.repository.UserCoachLikeRepository;
+import site.coach_coach.coach_coach_server.matching.domain.Matching;
+import site.coach_coach.coach_coach_server.matching.repository.MatchingRepository;
 import site.coach_coach.coach_coach_server.review.domain.Review;
 import site.coach_coach.coach_coach_server.review.dto.ReviewDto;
 import site.coach_coach.coach_coach_server.review.repository.ReviewRepository;
@@ -39,6 +41,7 @@ public class CoachService {
 	private final ReviewRepository reviewRepository;
 	private final UserCoachLikeRepository userCoachLikeRepository;
 	private final SportRepository sportRepository;
+	private final MatchingRepository matchingRepository;
 
 	@Transactional(readOnly = true)
 	public CoachDetailDto getCoachDetail(User user, Long coachId) {
@@ -154,6 +157,15 @@ public class CoachService {
 			.collect(Collectors.toList());
 
 		return new CoachListResponse(coaches, (int)coachesPage.getTotalElements(), page);
+	}
+
+	@Transactional
+	public void contactCoach(User user, Long coachId) {
+		Coach coach = coachRepository.findById(coachId)
+			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
+
+		Matching matching = new Matching(null, user.getUserId(), coachId, false);
+		matchingRepository.save(matching);
 	}
 
 	private int getCountOfLikes(Coach coach) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -161,7 +161,7 @@ public class CoachService {
 	}
 
 	@Transactional
-	public void contactCoach(User user, Long coachId) {
+	public Long contactCoach(User user, Long coachId) {
 		Coach coach = coachRepository.findById(coachId)
 			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
 
@@ -170,8 +170,11 @@ public class CoachService {
 
 		if (existingMatchingOpt.isEmpty()) {
 			Matching newMatching = new Matching(null, user, coach, false);
-			matchingRepository.save(newMatching);
+			Matching savedMatching = matchingRepository.save(newMatching);
+			return savedMatching.getUserCoachMatchingId();
 		}
+
+		return existingMatchingOpt.get().getUserCoachMatchingId();
 	}
 
 	private int getCountOfLikes(Coach coach) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -160,7 +160,7 @@ public class CoachService {
 		return new CoachListResponse(coaches, (int)coachesPage.getTotalElements(), page);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public void contactCoach(User user, Long coachId) {
 		Long userId = user.getUserId();
 		coachRepository.findById(coachId).orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -161,8 +161,7 @@ public class CoachService {
 
 	@Transactional
 	public void contactCoach(User user, Long coachId) {
-		Coach coach = coachRepository.findById(coachId)
-			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
+		coachRepository.findById(coachId).orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
 
 		Matching matching = new Matching(null, user.getUserId(), coachId, false);
 		matchingRepository.save(matching);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -161,10 +161,12 @@ public class CoachService {
 
 	@Transactional
 	public void contactCoach(User user, Long coachId) {
+		Long userId = user.getUserId();
 		coachRepository.findById(coachId).orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
 
-		Matching matching = new Matching(null, user.getUserId(), coachId, false);
-		matchingRepository.save(matching);
+		Matching existingMatching = matchingRepository.findByUserIdAndCoachId(userId, coachId)
+			.orElse(new Matching(null, userId, coachId, false));
+		matchingRepository.save(existingMatching);
 	}
 
 	private int getCountOfLikes(Coach coach) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -1,6 +1,7 @@
 package site.coach_coach.coach_coach_server.coach.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -164,9 +165,12 @@ public class CoachService {
 		Long userId = user.getUserId();
 		coachRepository.findById(coachId).orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
 
-		Matching existingMatching = matchingRepository.findByUserIdAndCoachId(userId, coachId)
-			.orElse(new Matching(null, userId, coachId, false));
-		matchingRepository.save(existingMatching);
+		Optional<Matching> existingMatchingOpt = matchingRepository.findByUserIdAndCoachId(userId, coachId);
+
+		if (existingMatchingOpt.isEmpty()) {
+			Matching newMatching = new Matching(null, userId, coachId, false);
+			matchingRepository.save(newMatching);
+		}
 	}
 
 	private int getCountOfLikes(Coach coach) {

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -42,6 +42,8 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_PAGE = "페이지 정보를 찾을 수 없습니다.";
 	public static final String INVALID_QUERY_PARAMETER = "잘못된 쿼리 파라미터입니다.";
 
+	public static final String DUPLICATE_CONTACT = "이미 문의 요청이 존재하는 코치입니다.";
+
 	public static final String CONVERT_FAIL = "파일 변환에 실패했습니다.";
 	public static final String INVALID_FILE_EXTENSION = "허용된 파일 확장자가 아닙니다.";
 	public static final String INVALID_FILE_NAME = "유효하지 않은 파일 이름입니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
@@ -12,7 +12,8 @@ public enum SuccessMessage {
 	PASSWORD_CONFIRM_SUCCESS("비밀번호 확인 성공"),
 	UPDATE_PROFILE_SUCCESS("수정 완료"),
 	CREATE_ROUTINE_SUCCESS("루틴 추가 성공"),
-	DELETE_ROUTINE_SUCCESS("루틴 삭제 성공");
+	DELETE_ROUTINE_SUCCESS("루틴 삭제 성공"),
+	CREATE_CONTACT_SUCCESS("문의 회원으로 등록되었습니다.");
 
 	private final String message;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
 
 import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
+import site.coach_coach.coach_coach_server.coach.exception.DuplicateContactException;
 import site.coach_coach.coach_coach_server.coach.exception.InvalidQueryParameterException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundPageException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundSportException;
@@ -137,6 +138,12 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(InvalidQueryParameterException.class)
 	public ResponseEntity<ErrorResponse> handleInvalidQueryParameterException(InvalidQueryParameterException ex) {
 		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
+	}
+
+	@ExceptionHandler(DuplicateContactException.class)
+	public ResponseEntity<ErrorResponse> handleDuplicateContactException(DuplicateContactException ex) {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/matching/domain/Matching.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/matching/domain/Matching.java
@@ -6,7 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,15 +20,14 @@ import site.coach_coach.coach_coach_server.common.domain.DateEntity;
 public class Matching extends DateEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@NotBlank
 	@Column(name = "user_coach_matching_id")
 	private Long userCoachMatchingId;
 
-	@NotBlank
+	@NotNull
 	@Column(name = "user_id")
 	private Long userId;
 
-	@NotBlank
+	@NotNull
 	@Column(name = "coach_id")
 	private Long coachId;
 

--- a/src/main/resources/db/migration/V6__modify_column_setting.sql
+++ b/src/main/resources/db/migration/V6__modify_column_setting.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `coachcoach`.`completed_categories`
+    ADD COLUMN `is_completed` TINYINT NOT NULL DEFAULT 1 AFTER `routine_category_id`;
+ALTER TABLE `coachcoach`.`users`
+    DROP COLUMN `local_info`;
+ALTER TABLE `coachcoach`.`coaching_sports`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`user_coach_likes`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`user_coach_matching`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`interested_sports`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`coaches`
+    CHANGE COLUMN `is_open` `is_open` TINYINT NOT NULL DEFAULT 1;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 문의하기 기능 API를 구현하였습니다.
  - API 요청 시 `user_coach_matching` 테이블에 사용자 ID(`userId`), 코치 ID(`coachId`), 그리고 is_matching 값이 `false`로 저장됩니다.
  - `userCoachMatchingId` 필드에서 `@NotNull` 어노테이션을 제거했습니다.
  - `Matching 엔티티`의 userId와 coachId에 대해 `@NotBlank`에서 `@NotNull`로 어노테이션을 변경하였습니다. 

### PR Point
- `MatchingService`의 `contactCoach` 메서드에서 `coachId` 검증 로직이 올바르게 동작하는지 확인해 주세요.
- 컨트롤러에서 성공 및 실패에 대한 적절한 HTTP 상태 코드와 메시지가 반환되는지 확인해 주세요.
- `user_coach_matching` 테이블에 이미 동일한 `userId`와 `coachId` 조합이 존재하는 경우 DB 변화는 없고 `200 ok`가 반환됩니다.
- 존재하지 않는 `coachId`를 호출할 경우 `404 Not Found`가 반환됩니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/1e91269c-0401-400b-9871-85e22426a911)| 형식에 맞춰 요청 시 200 반환|
|![image](https://github.com/user-attachments/assets/a485d182-ca1e-47e4-abaa-b2e4d0dbd9f4)| 존재하지 않는 `coachId`입력시 404 반환|


closed #131 