### PR TITLE
refactor(coach) : 전체 리스트 반환 로직 수정

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -90,13 +90,15 @@ public class CoachService {
 	public CoachListResponse getAllCoaches(User user, int page, String sports, String search, Boolean latest,
 		Boolean review, Boolean liked, Boolean my) {
 
+		List<Long> allSportsIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L);
+
 		Sort sort = Sort.by("updatedAt").descending();
 		Pageable pageable = PageRequest.of(page - 1, 20, sort);
 
-		List<Long> sportsList = (sports != null && !sports.isEmpty()) ? parseSports(sports) : null;
+		List<Long> sportsList = (sports != null && !sports.isEmpty()) ? parseSports(sports) : allSportsIds;
 		sportsList = getExistingSportsList(sportsList);
 
-		if (sports != null && !sports.isEmpty() && sportsList.isEmpty()) {
+		if (sportsList.isEmpty() && (sports != null && !sports.isEmpty())) {
 			return new CoachListResponse(List.of(), 0, page);
 		}
 
@@ -183,9 +185,6 @@ public class CoachService {
 	}
 
 	private List<Long> parseSports(String sports) {
-		if (sports == null || sports.isEmpty()) {
-			return List.of();
-		}
 		return Stream.of(sports.split(","))
 			.map(Long::parseLong)
 			.collect(Collectors.toList());

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -125,22 +125,21 @@ public class CoachService {
 		}
 
 		List<CoachingSport> existingSports = coachingSportRepository.findAllBySport_SportIdIn(sportsList);
-		List<Long> validSportIds = existingSports.stream()
+
+		return existingSports.stream()
 			.map(cs -> cs.getSport().getSportId())
 			.collect(Collectors.toList());
-
-		return validSportIds;
 	}
 
 	private Page<Coach> fetchCoachesPage(User user, List<Long> sportsList, String search, Pageable pageable,
 		Boolean review, Boolean liked, Boolean latest, Boolean my) {
-		if (review != null && review) {
+		if (Boolean.TRUE.equals(review)) {
 			return coachRepository.findAllWithReviewsSorted(sportsList, search, pageable);
-		} else if (liked != null && liked) {
+		} else if (Boolean.TRUE.equals(liked)) {
 			return coachRepository.findAllWithLikesSorted(sportsList, search, pageable);
-		} else if (latest != null && latest) {
+		} else if (Boolean.TRUE.equals(latest)) {
 			return coachRepository.findAllWithLatestSorted(sportsList, search, pageable);
-		} else if (my != null && my) {
+		} else if (Boolean.TRUE.equals(my)) {
 			return coachRepository.findMyCoaches(user.getUserId(), sportsList, search, pageable);
 		} else {
 			return coachRepository.findAllWithLatestSorted(sportsList, search, pageable);

--- a/src/main/java/site/coach_coach/coach_coach_server/sport/repository/CoachingSportRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/sport/repository/CoachingSportRepository.java
@@ -1,0 +1,13 @@
+package site.coach_coach.coach_coach_server.sport.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import site.coach_coach.coach_coach_server.sport.domain.CoachingSport;
+
+@Repository
+public interface CoachingSportRepository extends JpaRepository<CoachingSport, Long> {
+	List<CoachingSport> findAllBySport_SportIdIn(List<Long> sportIds);
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 스포츠 리스트 필터링 개선
  - `coaching_sports`테이블에 존재하지 않는 `sports ID`가 제공된 경우 빈 응답을 반환하도록 변경하였습니다.
- 빈 페이지 처리 로직 개선
  - 요청한 페이지가 총 페이지 수를 초과하는 경우 `404 Not Found` 오류를 반환하도록 수정하였습니다.
  - 페이지가 비어있을 때 첫 페이지 요청인 경우 빈 응답을 반환하도록 개선하였습니다.
- 코드 간결화
  - 스포츠 리스트 및 페이지 처리 로직을 별도의 메서드로 분리하여 메서드의 가독성을 높였습니다.
  - 조건 체크를 간소화하고 명확한 반환 로직을 추가하였습니다.

---

### PR Point
- 사용자가 원하는 정렬 기준(최신순, 리뷰순, 좋아요순 등)으로 조회가 되는지 확인해주세요
- `CoachingSports`에 등록되지 않은 `sportId`에 대해서 404가 아닌, 빈 배열로 나오는지 확인해주세요.
- 관심 코치에 등록한 코치(`my=true`)가 없을 경우 404가 아닌, 빈 배열로 나오는지 확인해주세요.
- 입력 받은 페이지(`?page=`)가 전체 페이지보다 클 경우 404가 반환되는지 확인해주세요.

### 📸 스크린샷
| 사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/a94cfc10-5a02-491e-950a-798aaf3cb82c)| `coaching_sports`테이블에 존재하는 `sports ID`인 경우 ( `sports=11`)|
|![image](https://github.com/user-attachments/assets/eac12040-d972-4cb5-be1a-a29492c466b5)| `coaching_sports`테이블에 존재하지 않는 `sports ID` ( `sports=10` )|
|![image](https://github.com/user-attachments/assets/9ff4a71c-87d9-4fd9-9bf6-91ed826bb5bc)| 관심 코치에 등록한 코치(`my=true`)가 있을 때 |
|![image](https://github.com/user-attachments/assets/56a4d23c-414d-4c72-b6ed-0abee3c23cb5)| 관심 코치에 등록한 코치(`my=true`)가 없을 때 빈 배열 반환|
|![image](https://github.com/user-attachments/assets/b8c23d71-468e-43aa-a1ef-28e835b26558)| 입력 받은 페이지(`?page=`)가 전체 페이지보다 클 경우 404가 반환 |


### 논의 사항 (선택)

closed #136 
