### PR TITLE
feat(notification) : 알림 개별 삭제 api 구현 

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ErrorMessage {
+	public static final String ACCESS_DENIED = "접근 권한이 없습니다.";
 	public static final String INVALID_REQUEST = "유효하지 않은 요청입니다.";
 	public static final String SERVER_ERROR = "서버 오류가 발생했습니다.";
 
@@ -30,6 +31,7 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_TOKEN = "토큰이 존재하지 않습니다.";
 	public static final String NOT_FOUND_ROUTINE = "존재하지 않는 루틴입니다.";
 	public static final String NOT_MY_ROUTINE = "접근 권한이 없습니다.";
+	public static final String NOT_FOUND_NOTIFICATION = "해당 알림을 찾을 수 없습니다.";
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
@@ -12,7 +12,8 @@ public enum SuccessMessage {
 	PASSWORD_CONFIRM_SUCCESS("비밀번호 확인 성공"),
 	UPDATE_PROFILE_SUCCESS("수정 완료"),
 	CREATE_ROUTINE_SUCCESS("루틴 추가 성공"),
-	DELETE_ROUTINE_SUCCESS("루틴 삭제 성공");
+	DELETE_ROUTINE_SUCCESS("루틴 삭제 성공"),
+	DELETE_NOTIFICATION_SUCCESS("알림 삭제 성공");
 
 	private final String message;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/AccessDeniedException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/AccessDeniedException.java
@@ -1,7 +1,9 @@
 package site.coach_coach.coach_coach_server.common.exception;
 
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+
 public class AccessDeniedException extends RuntimeException {
-	public AccessDeniedException(String message) {
-		super(message);
+	public AccessDeniedException() {
+		super(ErrorMessage.ACCESS_DENIED);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/AccessDeniedException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/AccessDeniedException.java
@@ -1,0 +1,7 @@
+package site.coach_coach.coach_coach_server.common.exception;
+
+public class AccessDeniedException extends RuntimeException {
+	public AccessDeniedException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -149,6 +149,13 @@ public class GlobalExceptionHandler {
 			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
 	}
 
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
+		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());
+		return ResponseEntity.status(HttpStatus.FORBIDDEN)
+			.body(new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
+	}
+
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception ex) {
 		Sentry.captureException(ex);

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
@@ -2,14 +2,19 @@ package site.coach_coach.coach_coach_server.notification.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
+import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
+import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.notification.dto.NotificationListResponse;
 import site.coach_coach.coach_coach_server.notification.service.NotificationService;
 
@@ -25,5 +30,16 @@ public class NotificationController {
 		Long userId = userDetails.getUserId();
 		List<NotificationListResponse> notifications = notificationService.getAllNotifications(userId);
 		return ResponseEntity.ok(notifications);
+	}
+
+	@DeleteMapping("/v1/notifications/{notificationId}")
+	public ResponseEntity<SuccessResponse> deleteNotification(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable("notificationId") Long notificationId) {
+		Long userId = customUserDetails.getUserId();
+		notificationService.deleteNotification(userId, notificationId);
+		return ResponseEntity.ok(
+			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_NOTIFICATION_SUCCESS.getMessage())
+		);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/exception/NotFoundException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package site.coach_coach.coach_coach_server.notification.exception;
+
+import java.util.NoSuchElementException;
+
+public class NotFoundException extends NoSuchElementException {
+	public NotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -10,11 +10,13 @@ import lombok.extern.slf4j.Slf4j;
 import site.coach_coach.coach_coach_server.coach.repository.CoachRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
+import site.coach_coach.coach_coach_server.common.exception.AccessDeniedException;
 import site.coach_coach.coach_coach_server.common.exception.InvalidInputException;
 import site.coach_coach.coach_coach_server.common.exception.UserNotFoundException;
 import site.coach_coach.coach_coach_server.notification.constants.NotificationMessage;
 import site.coach_coach.coach_coach_server.notification.domain.Notification;
 import site.coach_coach.coach_coach_server.notification.dto.NotificationListResponse;
+import site.coach_coach.coach_coach_server.notification.exception.NotFoundException;
 import site.coach_coach.coach_coach_server.notification.repository.NotificationRepository;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.exception.InvalidUserException;
@@ -59,6 +61,16 @@ public class NotificationService {
 			.relationFunction(relationFunction)
 			.build();
 		notificationRepository.save(notification);
+	}
+
+	public void deleteNotification(Long userId, Long notificationId) {
+		Notification notification = notificationRepository.findById(notificationId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_NOTIFICATION));
+
+		if (!notification.getUser().getUserId().equals(userId)) {
+			throw new AccessDeniedException(ErrorMessage.ACCESS_DENIED);
+		}
+		notificationRepository.delete(notification);
 	}
 
 	private String createMessage(User user, RelationFunctionEnum relationFunction) {

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -68,7 +68,7 @@ public class NotificationService {
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_NOTIFICATION));
 
 		if (!notification.getUser().getUserId().equals(userId)) {
-			throw new AccessDeniedException(ErrorMessage.ACCESS_DENIED);
+			throw new AccessDeniedException();
 		}
 		notificationRepository.delete(notification);
 	}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 알림 개별 삭제 api를 구현하였습니다. 
- 에러처리를 추가하였습니다.

### PR Point
- 존재하지 않는 알림의 경우 404 예외처리하였습니다.
- 자신의 알림이 아닌데 삭제할 경우 403 예외처리하였습니다.

### 📸 스크린샷
| 사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/3c1703b4-600a-47f6-9d15-ff4527a2b2c3)| 자신의 알림이 아님 |
|![image](https://github.com/user-attachments/assets/fe90f946-a4d3-4e02-8a70-76f9a62a76de)| 존재하지 않음 |
|![image](https://github.com/user-attachments/assets/e7d71579-ac2b-405f-b9e4-bed258289446)| 알림 삭제 성공 |

### 논의 사항 (선택)
- 내 알림도 아니고 존재하지도 않는 알림..의 경우에 대한 우선순위를 못 정해서 일단 404먼저 처리하도록 하였습니다!
- 호옥시 403이 먼저 처리되는 게 나을 것 같으면 말씀해주세요!

closed #140 
