### PR TITLE
feat(notification) : 알림 전체 삭제 api 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/controller/NotificationController.java
@@ -32,6 +32,16 @@ public class NotificationController {
 		return ResponseEntity.ok(notifications);
 	}
 
+	@DeleteMapping("/v1/notifications")
+	public ResponseEntity<SuccessResponse> deleteAllNotifications(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		Long userId = userDetails.getUserId();
+		notificationService.deleteAllNotifications(userId);
+		return ResponseEntity.ok(
+			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_NOTIFICATION_SUCCESS.getMessage())
+		);
+	}
+
 	@DeleteMapping("/v1/notifications/{notificationId}")
 	public ResponseEntity<SuccessResponse> deleteNotification(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package site.coach_coach.coach_coach_server.notification.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -71,6 +72,14 @@ public class NotificationService {
 			throw new AccessDeniedException();
 		}
 		notificationRepository.delete(notification);
+	}
+
+	public void deleteAllNotifications(Long userId) {
+		User user = userRepository.findById(userId).orElseThrow(InvalidUserException::new);
+		List<Notification> notifications = new ArrayList<>(user.getNotifications());
+		if (!notifications.isEmpty()) {
+			notificationRepository.deleteAll(notifications);
+		}
 	}
 
 	private String createMessage(User user, RelationFunctionEnum relationFunction) {


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 알림 전체 삭제 api를 구현하였습니다.

### PR Point
- 사용자는 자신의 알림을 전체 삭제합니다.
- 알림이 없는 경우에 에러처리를 하지는 않았습니다 

### 📸 스크린샷
| 사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/22d1ef7b-889e-43a3-9603-1af193277f06) | 알림 삭제 성공 |

### 논의 사항 (선택)
- V6 때문에 오류가 .. 발생하여 애플리케이션이 시작이 안 되어서 삭제한 채로 테스트했었습니다...
  - 일단 삭제한 거는 commit에 안 올렸어요! 
  - 근데 이 상태로는 배포를 해도.. 아까처럼 rds 문제생길 것 같아서 걱정이네욤 ㅠ_ㅠ

closed #이슈번호
