### PR TITLE
chore(flyway) : config파일 & V7 sql 파일 추가

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/config/FlywayConfig.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/config/FlywayConfig.java
@@ -1,0 +1,17 @@
+package site.coach_coach.coach_coach_server.config;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+	@Bean
+	public FlywayMigrationStrategy cleanMigrateStrategy() {
+		return flyway -> {
+			flyway.repair();
+			flyway.migrate();
+		};
+	}
+}

--- a/src/main/resources/db/migration/V7__modify_column_setting.sql
+++ b/src/main/resources/db/migration/V7__modify_column_setting.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `coachcoach`.`completed_categories`
+    DROP COLUMN `is_completed`;
+ALTER TABLE `coachcoach`.`routine_categories`
+    ADD COLUMN `is_completed` TINYINT NOT NULL DEFAULT 0 AFTER `category_name`;
+ALTER TABLE `coachcoach`.`actions`
+    CHANGE COLUMN `set` `sets` INT NULL DEFAULT NULL;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- `flywayConfig` 파일을 추가해 `repair()`를 통해 `checksum` 재설정 할 수 있게 했습니다.
  - `Migration checksum mismatch for migration version` 으로 `checksum`의 버전이 일치하지 않아서 생기는 문제 해결
- V7 파일 추가


closed #156
