### PR TITLE
refactor(coach) : 코치 정보 조회 로직 수정

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -27,11 +27,8 @@ public class CoachController {
 	@GetMapping("/v1/coaches")
 	public ResponseEntity<CoachDetailDto> getCoachDetail(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "coachId") Long coachId
+		@RequestParam(name = "coachId", required = false) Long coachId
 	) {
-		if (userDetails == null || userDetails.getUser() == null) {
-			throw new InvalidUserException();
-		}
 		User user = userDetails.getUser();
 		CoachDetailDto response = coachService.getCoachDetail(user, coachId);
 		return ResponseEntity.ok(response);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -15,6 +15,9 @@ import site.coach_coach.coach_coach_server.user.domain.User;
 
 @Repository
 public interface CoachRepository extends JpaRepository<Coach, Long> {
+
+	Optional<Coach> findByUser_UserId(Long userId);
+
 	@Query("SELECT c.user FROM Coach c WHERE c.coachId = :coachId")
 	Optional<User> findUserByCoachId(@Param("coachId") Long coachId);
 

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -20,6 +20,7 @@ import site.coach_coach.coach_coach_server.coach.exception.NotFoundCoachExceptio
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundPageException;
 import site.coach_coach.coach_coach_server.coach.repository.CoachRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+import site.coach_coach.coach_coach_server.common.exception.AccessDeniedException;
 import site.coach_coach.coach_coach_server.like.repository.UserCoachLikeRepository;
 import site.coach_coach.coach_coach_server.review.domain.Review;
 import site.coach_coach.coach_coach_server.review.dto.ReviewDto;
@@ -39,31 +40,27 @@ public class CoachService {
 	private final CoachingSportRepository coachingSportRepository;
 
 	@Transactional(readOnly = true)
+	public Coach getCoach(User user, Long coachId) {
+		if (coachId == null) {
+			return coachRepository.findByUser_UserId(user.getUserId())
+				.orElseThrow(AccessDeniedException::new);
+		} else {
+			return coachRepository.findById(coachId)
+				.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
+		}
+	}
+
+	@Transactional(readOnly = true)
 	public CoachDetailDto getCoachDetail(User user, Long coachId) {
-		Coach coach = coachRepository.findById(coachId)
-			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
+		Coach coach = getCoach(user, coachId);
 
-		List<ReviewDto> reviews = reviewRepository.findByCoach_CoachId(coach.getCoachId()).stream()
-			.map(review -> new ReviewDto(
-				review.getUser().getUserId(),
-				review.getUser().getNickname(),
-				review.getContents(),
-				review.getStars(),
-				review.getCreatedAt().toString()
-			))
-			.collect(Collectors.toList());
-
-		double averageRating = reviews.stream().mapToInt(ReviewDto::stars).average().orElse(0.0);
+		List<ReviewDto> reviews = getReviews(coach);
+		double averageRating = calculateAverageRating(reviews);
 
 		boolean isLiked = isLikedByUser(user, coach);
 		int countOfLikes = getCountOfLikes(coach);
 
-		List<CoachingSportDto> coachingSports = coach.getCoachingSports().stream()
-			.map(cs -> new CoachingSportDto(
-				cs.getSport().getSportId(),
-				cs.getSport().getSportName()
-			))
-			.collect(Collectors.toList());
+		List<CoachingSportDto> coachingSports = getCoachingSports(coach);
 
 		return CoachDetailDto.builder()
 			.coachName(coach.getUser().getNickname())
@@ -173,6 +170,32 @@ public class CoachService {
 			.isLiked(isLiked)
 			.countOfLikes(countOfLikes)
 			.build();
+	}
+
+	@Transactional(readOnly = true)
+	public List<ReviewDto> getReviews(Coach coach) {
+		return reviewRepository.findByCoach_CoachId(coach.getCoachId()).stream()
+			.map(review -> new ReviewDto(
+				review.getUserId(),
+				review.getUserNickname(),
+				review.getContents(),
+				review.getStars(),
+				review.getCreatedAt().toString()
+			))
+			.collect(Collectors.toList());
+	}
+
+	public List<CoachingSportDto> getCoachingSports(Coach coach) {
+		return coach.getCoachingSports().stream()
+			.map(cs -> new CoachingSportDto(
+				cs.getSportId(),
+				cs.getSportName()
+			))
+			.collect(Collectors.toList());
+	}
+
+	public double calculateAverageRating(List<ReviewDto> reviews) {
+		return reviews.stream().mapToInt(ReviewDto::stars).average().orElse(0.0);
 	}
 
 	private int getCountOfLikes(Coach coach) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -40,19 +40,20 @@ public class CoachService {
 	private final CoachingSportRepository coachingSportRepository;
 
 	@Transactional(readOnly = true)
-	public Coach getCoach(User user, Long coachId) {
-		if (coachId == null) {
-			return coachRepository.findByUser_UserId(user.getUserId())
-				.orElseThrow(AccessDeniedException::new);
-		} else {
-			return coachRepository.findById(coachId)
-				.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
-		}
+	public Coach getCoachById(Long coachId) {
+		return coachRepository.findById(coachId)
+			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
+	}
+
+	@Transactional(readOnly = true)
+	public Coach getCoachByUserId(User user) {
+		return coachRepository.findByUser_UserId(user.getUserId())
+			.orElseThrow(AccessDeniedException::new);
 	}
 
 	@Transactional(readOnly = true)
 	public CoachDetailDto getCoachDetail(User user, Long coachId) {
-		Coach coach = getCoach(user, coachId);
+		Coach coach = (coachId != null) ? getCoachById(coachId) : getCoachByUserId(user);
 
 		List<ReviewDto> reviews = getReviews(coach);
 		double averageRating = calculateAverageRating(reviews);

--- a/src/main/java/site/coach_coach/coach_coach_server/review/domain/Review.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/review/domain/Review.java
@@ -52,4 +52,12 @@ public class Review extends DateEntity {
 	@NotNull
 	@Column(name = "stars")
 	private int stars;
+
+	public Long getUserId() {
+		return this.user.getUserId();
+	}
+
+	public String getUserNickname() {
+		return this.user.getNickname();
+	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/sport/domain/CoachingSport.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/sport/domain/CoachingSport.java
@@ -41,4 +41,12 @@ public class CoachingSport extends DateEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "sport_id")
 	private Sport sport;
+
+	public Long getSportId() {
+		return this.sport.getSportId();
+	}
+
+	public String getSportName() {
+		return this.sport.getSportName();
+	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 코치 상세 정보 조회 로직을 추가했습니다.
  - 기존 기능 : Query Params으로 `coachId`로 코치의 상세 정보를 조회.
  - 추가 기능 : Query Params으로`coachId`가 주어지지 않았을 경우, JWT 토큰에서 userId를 추출하여 해당 userId에 연결된 코치의 상세 정보를 조회합니다.
    - 코치 존재 : 코치의 상세 정보를 반환.
    - 코치 미존재 : 접근 권한 없음 예외 발생.
- 메서드 분리 : `getCoachDetail` 메서드를 기능별로 분리하여 가독성과 유지보수성을 향상.
- 디미터의 법칙 적용 : `getCoachingSports` 메서드에서 직접적으로 Sport 객체의 속성에 접근하지 않고, DTO를 통해 데이터를 처리하도록 수정.

### PR Point
- Query Params으로 `coachId`가 주어지지 않았을 경우, 사용자의 userId에 연결된 코치의 상세 정보를 조회하는지 확인해주세요.
- `coachId`가 존재하지 않는 사용자인 경우, 403을 반환합니다.
- 존재하지 않는 `coachId`가 주어진 경우, 404를 반환합니다.
### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/a140eca2-2cd3-4bb3-b1a0-8e0294461867)| Query Params으로 `coachId`가 주어진 경우|
|![image](https://github.com/user-attachments/assets/b0ffa64b-bf31-4c9d-bcb6-7db0cfd433a2)|  Query Params으로 `coachId`가 주어지지 않았을 경우, 사용자의 userId에 연결된 코치의 상세 정보를 조회 |
|![image](https://github.com/user-attachments/assets/5bca9b11-ef1d-458a-822c-06fe65c83026)| Query Params으로 `coachId`가 주어지지 않고 `coachId`가 존재하지 않는 사용자인 경우, 403을 반환|
|![image](https://github.com/user-attachments/assets/db8cdec6-318c-4744-b9dc-b3fc61616739)| 존재하지 않는 `coachId`가 주어진 경우, 404를 반환 |

closed #138
