### PR TITLE
feat(coach) : 관심 코치(좋아요) 취소 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -3,6 +3,7 @@ package site.coach_coach.coach_coach_server.coach.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -94,5 +95,16 @@ public class CoachController {
 		coachService.contactCoach(user, coachId);
 		return ResponseEntity.ok(
 			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.CREATE_CONTACT_SUCCESS.getMessage()));
+	}
+
+	@DeleteMapping("/v1/coaches/{coachId}/likes")
+	public ResponseEntity<SuccessResponse> cancelLikeCoach(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable Long coachId) {
+
+		Long userId = userDetails.getUserId();
+		coachService.cancelLikeCoach(userId, coachId);
+		return ResponseEntity.ok()
+			.body(new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_LIKE_SUCCESS.getMessage()));
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -98,12 +98,12 @@ public class CoachController {
 	}
 
 	@DeleteMapping("/v1/coaches/{coachId}/likes")
-	public ResponseEntity<SuccessResponse> cancelLikeCoach(
+	public ResponseEntity<SuccessResponse> deleteCoachToFavorites(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable Long coachId) {
 
 		Long userId = userDetails.getUserId();
-		coachService.cancelLikeCoach(userId, coachId);
+		coachService.deleteCoachToFavorites(userId, coachId);
 		return ResponseEntity.ok()
 			.body(new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_LIKE_SUCCESS.getMessage()));
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -209,6 +209,21 @@ public class CoachService {
 		return new CoachListResponse(coaches, (int)coachesPage.getTotalElements(), page);
 	}
 
+	@Transactional
+	public void cancelLikeCoach(Long userId, Long coachId) {
+		validateUserAndCoach(userId, coachId);
+		userCoachLikeRepository.deleteByUser_UserIdAndCoach_CoachId(userId, coachId);
+	}
+
+	private void validateUserAndCoach(Long userId, Long coachId) {
+		if (!userRepository.existsById(userId)) {
+			throw new InvalidUserException();
+		}
+		if (!coachRepository.existsById(coachId)) {
+			throw new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH);
+		}
+	}
+
 	private List<Long> getExistingSportsList(List<Long> sportsList) {
 		if (sportsList == null || sportsList.isEmpty()) {
 			return List.of();

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -211,17 +211,10 @@ public class CoachService {
 
 	@Transactional
 	public void cancelLikeCoach(Long userId, Long coachId) {
-		validateUserAndCoach(userId, coachId);
-		userCoachLikeRepository.deleteByUser_UserIdAndCoach_CoachId(userId, coachId);
-	}
+		coachRepository.findById(coachId)
+			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
 
-	private void validateUserAndCoach(Long userId, Long coachId) {
-		if (!userRepository.existsById(userId)) {
-			throw new InvalidUserException();
-		}
-		if (!coachRepository.existsById(coachId)) {
-			throw new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH);
-		}
+		userCoachLikeRepository.deleteByUser_UserIdAndCoach_CoachId(userId, coachId);
 	}
 
 	private List<Long> getExistingSportsList(List<Long> sportsList) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -210,11 +210,13 @@ public class CoachService {
 	}
 
 	@Transactional
-	public void cancelLikeCoach(Long userId, Long coachId) {
+	public void deleteCoachToFavorites(Long userId, Long coachId) {
 		coachRepository.findById(coachId)
 			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
 
-		userCoachLikeRepository.deleteByUser_UserIdAndCoach_CoachId(userId, coachId);
+		if (userCoachLikeRepository.existsByUser_UserIdAndCoach_CoachId(userId, coachId)) {
+			userCoachLikeRepository.deleteByUser_UserIdAndCoach_CoachId(userId, coachId);
+		}
 	}
 
 	private List<Long> getExistingSportsList(List<Long> sportsList) {

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
@@ -17,7 +17,8 @@ public enum SuccessMessage {
 	UPDATE_COACH_PROFILE_SUCCESS("업로드 성공"),
 	DELETE_NOTIFICATION_SUCCESS("알림 삭제 성공"),
 	MATCH_MEMBER_SUCCESS("관리 회원에 등록되었습니다."),
-	CREATE_CONTACT_SUCCESS("문의 회원으로 등록되었습니다.");
+	CREATE_CONTACT_SUCCESS("문의 회원으로 등록되었습니다."),
+	DELETE_LIKE_SUCCESS("관심 코치 취소 되었습니다.");
 
 	private final String message;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/like/repository/UserCoachLikeRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/like/repository/UserCoachLikeRepository.java
@@ -16,6 +16,8 @@ public interface UserCoachLikeRepository extends JpaRepository<UserCoachLike, Lo
 
 	boolean existsByUser_UserIdAndCoach_CoachId(Long userId, Long coachId);
 
+	void deleteByUser_UserIdAndCoach_CoachId(Long userId, Long coachId);
+
 	@Query("SELECT u.coach FROM UserCoachLike u "
 		+ "WHERE u.createdAt >= :startDate GROUP BY u.coach ORDER BY COUNT(u) DESC")
 	List<Coach> findTopCoachesByLikesSince(@Param("startDate") LocalDateTime startDate, Pageable pageable);

--- a/src/main/resources/db/migration/V6__modify_column_setting.sql
+++ b/src/main/resources/db/migration/V6__modify_column_setting.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `coachcoach`.`completed_categories`
+    ADD COLUMN `is_completed` TINYINT NOT NULL DEFAULT 1 AFTER `routine_category_id`;
+ALTER TABLE `coachcoach`.`users`
+    DROP COLUMN `local_info`;
+ALTER TABLE `coachcoach`.`coaching_sports`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`user_coach_likes`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`user_coach_matching`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`interested_sports`
+    CHANGE COLUMN `updated_at` `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `coachcoach`.`coaches`
+    CHANGE COLUMN `is_open` `is_open` TINYINT NOT NULL DEFAULT 1;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 관심 코치 취소 기능을 구현했습니다.
  - 사용자와 코치 간의 '좋아요(`like`)' 관계를 처리하는 API를 구현하였습니다.
  - API 요청 시, JWT에서 추출한 `userId`와 `coachId`의 조합을 바탕으로 `user_coach_likes` 테이블에서 해당 엔트리가 존재하는 경우 삭제합니다. 
  - 성공적으로 삭제했을 경우, 200 상태 코드와 함께 "관심 코치 취소 되었습니다."라는 메시지를 반환합니다.
  - `coachId`가 유효하지 않은 경우, 404 상태 코드와 함께 "존재하지 않는 코치입니다."라는 메시지를 반환합니다.

### 📸 스크린샷
|설명|사진|
|---|---|
|![image](https://github.com/user-attachments/assets/5565e93a-22b6-4a25-85fe-54fad81c5d0d)| 성공적으로 취소(삭제)됨 |
|![image](https://github.com/user-attachments/assets/c0f31c3b-2df3-4672-8bfd-ca0d41f2edf9)| 유효하지 않은 `coachId` 요청 시|


closed #177