### PR TITLE
refactor(coach) : 코치 정보 등록/수정 API SportName

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -22,6 +22,7 @@ import site.coach_coach.coach_coach_server.coach.exception.DuplicateContactExcep
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundCoachException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundMatchingException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundPageException;
+import site.coach_coach.coach_coach_server.coach.exception.NotFoundSportException;
 import site.coach_coach.coach_coach_server.coach.repository.CoachRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
@@ -85,11 +86,10 @@ public class CoachService {
 
 	@Transactional
 	public void addNewCoachingSports(Coach coach, List<CoachingSportDto> coachingSports) {
-		List<Long> sportIds = coachingSports.stream()
-			.map(CoachingSportDto::sportId)
-			.collect(Collectors.toList());
-
-		List<Sport> sports = sportRepository.findAllById(sportIds);
+		List<Sport> sports = coachingSports.stream()
+			.map(coachingSportDto -> sportRepository.findBySportName(coachingSportDto.sportName())
+				.orElseThrow(() -> new NotFoundSportException(ErrorMessage.NOT_FOUND_SPORTS)))
+			.toList();
 
 		List<CoachingSport> coachingSportsEntities = sports.stream()
 			.map(sport -> new CoachingSport(coach, sport))


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 코치 정보 등록/수정 API 기능에 대해 수정했습니다.
  - request값으로 coachingSports에 대해서 `sportId` 대신 `sportName` 값을 사용하도록 수정
 
### PR Point
- 기존 sportId 관련 로직이 `sportName`으로 제대로 대체되었는지 확인해주세요.
  - `addNewCoachingSports` 메서드에서 `sportName`으로 Sport 객체를 정확하게 조회하고 있는지 확인
- 기존의 `sportId`를 사용하던 다른 메서드나 로직에 영향이 없는지 확인해주세요.
  - API 요청 및 응답이 변경된 사항에 따라 기존 클라이언트와의 호환성에 문제가 없는지 점검

### 📸 스크린샷
|설명|사진|
|---|---|
|![image](https://github.com/user-attachments/assets/95605182-ef09-4279-bd6e-e297441daa40)| `sportId`대신 `sportName`으로 요청 시에 정상적으로 업로드 성공 |
|![image](https://github.com/user-attachments/assets/005aeefa-2d28-4596-8e7e-504f411d1c76)| 종목 정보를 잘못 입력할 경우 404 반환|


closed #180
