### PR TITLE
feat(record) : 신체 정보 수정 api 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -31,7 +31,7 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_TOKEN = "토큰이 존재하지 않습니다.";
 	public static final String NOT_FOUND_ROUTINE = "존재하지 않는 루틴입니다.";
 	public static final String NOT_FOUND_CATEGORY = "존재하지 않는 카테고리입니다.";
-	public static final String NOT_MY_ROUTINE = "접근 권한이 없습니다.";
+	public static final String NOT_FOUND_RECORD = "존재하지 않는 기록입니다.";
 	public static final String NOT_FOUND_NOTIFICATION = "해당 알림을 찾을 수 없습니다.";
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
@@ -43,7 +43,7 @@ public class UserRecordController {
 		@RequestBody @Valid UserRecordUpdateRequest userRecordUpdateRequest
 	) {
 		Long userId = userDetails.getUserId();
-		userRecordService.updateBodyInfoToUserRecord(recordId, userId, userRecordUpdateRequest);
+		userRecordService.updateBodyInfoToUserRecord(userId, recordId, userRecordUpdateRequest);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
@@ -3,16 +3,20 @@ package site.coach_coach.coach_coach_server.userrecord.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.common.response.SuccessIdResponse;
 import site.coach_coach.coach_coach_server.userrecord.dto.UserRecordCreateRequest;
+import site.coach_coach.coach_coach_server.userrecord.dto.UserRecordUpdateRequest;
 import site.coach_coach.coach_coach_server.userrecord.service.UserRecordService;
 
 @RestController
@@ -30,5 +34,16 @@ public class UserRecordController {
 		Long recordId = userRecordService.addBodyInfoToUserRecord(userId, userRecordCreateRequest);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(new SuccessIdResponse(recordId));
+	}
+
+	@PutMapping("/v1/records/{recordId}")
+	public ResponseEntity<Void> updateBodyInfoToUserRecord(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable("recordId") @Positive Long recordId,
+		@RequestBody @Valid UserRecordUpdateRequest userRecordUpdateRequest
+	) {
+		Long userId = userDetails.getUserId();
+		userRecordService.updateBodyInfoToUserRecord(recordId, userId, userRecordUpdateRequest);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/domain/UserRecord.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/domain/UserRecord.java
@@ -50,4 +50,11 @@ public class UserRecord extends DateEntity {
 	@NotNull
 	@Column(name = "record_date")
 	private LocalDate recordDate;
+
+	public void updateBodyInfo(Double weight, Double skeletalMuscle, Double fatPercentage, Double bmi) {
+		this.weight = weight;
+		this.skeletalMuscle = skeletalMuscle;
+		this.fatPercentage = fatPercentage;
+		this.bmi = bmi;
+	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/dto/UserRecordUpdateRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/dto/UserRecordUpdateRequest.java
@@ -1,0 +1,9 @@
+package site.coach_coach.coach_coach_server.userrecord.dto;
+
+public record UserRecordUpdateRequest(
+	Double weight,
+	Double skeletalMuscle,
+	Double fatPercentage,
+	Double bmi
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
@@ -9,12 +9,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+import site.coach_coach.coach_coach_server.common.exception.AccessDeniedException;
 import site.coach_coach.coach_coach_server.common.exception.InvalidInputException;
+import site.coach_coach.coach_coach_server.notification.exception.NotFoundException;
 import site.coach_coach.coach_coach_server.user.domain.User;
 import site.coach_coach.coach_coach_server.user.exception.InvalidUserException;
 import site.coach_coach.coach_coach_server.user.repository.UserRepository;
 import site.coach_coach.coach_coach_server.userrecord.domain.UserRecord;
 import site.coach_coach.coach_coach_server.userrecord.dto.UserRecordCreateRequest;
+import site.coach_coach.coach_coach_server.userrecord.dto.UserRecordUpdateRequest;
 import site.coach_coach.coach_coach_server.userrecord.exception.DuplicateRecordException;
 import site.coach_coach.coach_coach_server.userrecord.repository.UserRecordRepository;
 
@@ -46,6 +49,24 @@ public class UserRecordService {
 		userRecordRepository.save(userRecord);
 
 		return userRecord.getUserRecordId();
+	}
+
+	@Transactional
+	public void updateBodyInfoToUserRecord(Long recordId, Long userId,
+		UserRecordUpdateRequest userRecordUpdateRequest) {
+		UserRecord userRecord = userRecordRepository.findById(recordId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_RECORD));
+
+		if (!userRecord.getUser().getUserId().equals(userId)) {
+			throw new AccessDeniedException();
+		}
+		
+		userRecord.updateBodyInfo(
+			userRecordUpdateRequest.weight(),
+			userRecordUpdateRequest.skeletalMuscle(),
+			userRecordUpdateRequest.fatPercentage(),
+			userRecordUpdateRequest.bmi()
+		);
 	}
 
 	private LocalDate validateAndConvertToLocalDate(String date) {

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
@@ -52,7 +52,7 @@ public class UserRecordService {
 	}
 
 	@Transactional
-	public void updateBodyInfoToUserRecord(Long recordId, Long userId,
+	public void updateBodyInfoToUserRecord(Long userId, Long recordId,
 		UserRecordUpdateRequest userRecordUpdateRequest) {
 		UserRecord userRecord = userRecordRepository.findById(recordId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_RECORD));
@@ -60,7 +60,7 @@ public class UserRecordService {
 		if (!userRecord.getUser().getUserId().equals(userId)) {
 			throw new AccessDeniedException();
 		}
-		
+
 		userRecord.updateBodyInfo(
 			userRecordUpdateRequest.weight(),
 			userRecordUpdateRequest.skeletalMuscle(),


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 신체 정보 수정 api를 구현하였습니다. (성공 시 204)
- 신체 정보 폼 입력하지 않을 때와 존재하지 않는 record일때, 본인의 record가 아닐때에 대하여 에러 처리하였습니다. 

### PR Point
- 에러 처리가 필요한 부분이 더 있나 확인해주세요!
- 에러 처리가 잘 되는지 확인해주세요!
- 정보가 잘 수정되는지 확인해주세요! 

### 📸 스크린샷
| 사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/0ce5546c-753d-466f-a17e-0628f8b745b2)|남의 기록 보기|
|![image](https://github.com/user-attachments/assets/49d0e5a2-0461-4b91-97e9-c9285158a484)| 존재하지 않는 기록 |
|![image](https://github.com/user-attachments/assets/324da297-d3cb-4ea1-a383-9fb53f7d4d79)| recordId validate 실패 |
|![image](https://github.com/user-attachments/assets/25df3c11-6a12-4b1b-abcb-e4f9f939e31a)| 기록 업데이트 성공 |


closed #191 
