### PR TITLE
feat(user) : 문의/매칭 코치 조회 기능 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -21,6 +21,7 @@ import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.coach.dto.CoachDetailDto;
 import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
 import site.coach_coach.coach_coach_server.coach.dto.CoachRequest;
+import site.coach_coach.coach_coach_server.coach.dto.MatchingCoachResponseDto;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingUserResponseDto;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
 import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
@@ -142,5 +143,15 @@ public class CoachController {
 		List<MatchingUserResponseDto> matchingUsers = coachService.getMatchingUsersByCoachId(coachUserId);
 
 		return ResponseEntity.ok(matchingUsers);
+	}
+
+	@GetMapping("/v1/users/matches")
+	public ResponseEntity<List<MatchingCoachResponseDto>> getMatchingCoaches(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		Long userId = userDetails.getUser().getUserId();
+		List<MatchingCoachResponseDto> matchingCoaches = coachService.getMatchingCoachesByUserId(userId);
+
+		return ResponseEntity.ok(matchingCoaches);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -149,7 +149,7 @@ public class CoachController {
 	public ResponseEntity<List<MatchingCoachResponseDto>> getMatchingCoaches(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 
-		Long userId = userDetails.getUser().getUserId();
+		Long userId = userDetails.getUserId();
 		List<MatchingCoachResponseDto> matchingCoaches = coachService.getMatchingCoachesByUserId(userId);
 
 		return ResponseEntity.ok(matchingCoaches);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/MatchingCoachResponseDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/MatchingCoachResponseDto.java
@@ -1,0 +1,9 @@
+package site.coach_coach.coach_coach_server.coach.dto;
+
+public record MatchingCoachResponseDto(
+	Long coachId,
+	String coachName,
+	String profileImageUrl,
+	boolean isMatching
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -17,6 +17,7 @@ import site.coach_coach.coach_coach_server.coach.dto.CoachDetailDto;
 import site.coach_coach.coach_coach_server.coach.dto.CoachListDto;
 import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
 import site.coach_coach.coach_coach_server.coach.dto.CoachRequest;
+import site.coach_coach.coach_coach_server.coach.dto.MatchingCoachResponseDto;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingUserResponseDto;
 import site.coach_coach.coach_coach_server.coach.exception.AlreadyMatchedException;
 import site.coach_coach.coach_coach_server.coach.exception.DuplicateContactException;
@@ -268,6 +269,25 @@ public class CoachService {
 			user.getUserId(),
 			user.getNickname(),
 			user.getProfileImageUrl(),
+			matching.getIsMatching()
+		);
+	}
+
+	public List<MatchingCoachResponseDto> getMatchingCoachesByUserId(Long userId) {
+		List<Matching> matchings = matchingRepository.findByUser_UserId(userId);
+
+		return matchings.stream()
+			.map(this::buildMatchingCoachResponseDto)
+			.collect(Collectors.toList());
+	}
+
+	private MatchingCoachResponseDto buildMatchingCoachResponseDto(Matching matching) {
+		Coach coach = matching.getCoach();
+
+		return new MatchingCoachResponseDto(
+			coach.getCoachId(),
+			coach.getUser().getNickname(),
+			coach.getUser().getProfileImageUrl(),
 			matching.getIsMatching()
 		);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/matching/repository/MatchingRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/matching/repository/MatchingRepository.java
@@ -15,4 +15,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 	boolean existsByUserUserIdAndCoachCoachId(Long userId, Long coachId);
 
 	List<Matching> findByCoach_CoachId(Long coachId);
+
+	List<Matching> findByUser_UserId(Long userId);
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 회원 관점에서의 매칭/문의된 코치 목록 조회하는 기능을 구현했습니다.
  - 기존의 매칭된 회원 조회 API와 유사한 구조로, 회원이 자신과 매칭되거나 문의한 코치들을 쉽게 조회할 수 있도록 구현했습니다.
  - 데이터베이스에서 userId를 기반으로 Matching 엔티티를 조회하여, 코치 정보를 반환하는 방식을 사용하였습니다.
  
### PR Point
- 접속한 회원의 userId로 문의/매칭 코치들의 정보를 리스트 형식으로 반환합니다.
- 문의/매칭 코치는 isMatching값으로 구분합니다. 
- 문의/매칭 코치가 없을 경우 빈 배열로 전달합니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/caea40c3-ad28-47ff-bab4-0cfa7e087a8c)| 문의 코치: `false`, 매칭 코치 : `true` |
|![image](https://github.com/user-attachments/assets/c3281b1c-6da5-4640-b4d5-5cf0e183d1a6)| 문의/매칭 회원이 없을 경우 빈배열 반환 |

closed #195
