### PR TITLE
feat(action) : 운동 추가 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
@@ -1,0 +1,37 @@
+package site.coach_coach.coach_coach_server.action.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import site.coach_coach.coach_coach_server.action.dto.CreateActionRequest;
+import site.coach_coach.coach_coach_server.action.dto.CreateActionResponse;
+import site.coach_coach.coach_coach_server.action.service.ActionService;
+import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ActionController {
+	private final ActionService actionService;
+
+	@PostMapping("/v1/routines/{routineId}/{categoryId}")
+	public ResponseEntity<CreateActionResponse> createAction(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable(name = "routineId") Long routineId,
+		@PathVariable(name = "categoryId") Long categoryId,
+		@RequestBody @Valid CreateActionRequest createActionRequest
+	) {
+		Long userIdByJwt = userDetails.getUserId();
+		Long actionId = actionService.createAction(routineId, categoryId, userIdByJwt, createActionRequest);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(new CreateActionResponse(actionId));
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.action.dto.CreateActionRequest;
-import site.coach_coach.coach_coach_server.action.dto.CreateActionResponse;
 import site.coach_coach.coach_coach_server.action.service.ActionService;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
+import site.coach_coach.coach_coach_server.common.response.SuccessIdResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,7 +23,7 @@ public class ActionController {
 	private final ActionService actionService;
 
 	@PostMapping("/v1/routines/{routineId}/{categoryId}")
-	public ResponseEntity<CreateActionResponse> createAction(
+	public ResponseEntity<SuccessIdResponse> createAction(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable(name = "routineId") Long routineId,
 		@PathVariable(name = "categoryId") Long categoryId,
@@ -32,6 +32,6 @@ public class ActionController {
 		Long userIdByJwt = userDetails.getUserId();
 		Long actionId = actionService.createAction(routineId, categoryId, userIdByJwt, createActionRequest);
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(new CreateActionResponse(actionId));
+			.body(new SuccessIdResponse(actionId));
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/domain/Action.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/domain/Action.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.coach_coach.coach_coach_server.action.dto.CreateActionRequest;
 import site.coach_coach.coach_coach_server.category.domain.Category;
 import site.coach_coach.coach_coach_server.common.domain.DateEntity;
 
@@ -35,9 +36,8 @@ public class Action extends DateEntity {
 	@Column(name = "action_name")
 	private String actionName;
 
-	@Size(max = 45)
 	@Column(name = "sets")
-	private String sets;
+	private int sets;
 
 	@Size(max = 45)
 	@Column(name = "count_or_minutes")
@@ -50,4 +50,14 @@ public class Action extends DateEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "routine_category_id")
 	private Category category;
+
+	public static Action of(CreateActionRequest createActionRequest, Category category) {
+		return Action.builder()
+			.actionName(createActionRequest.actionName())
+			.sets(createActionRequest.sets())
+			.countOrMinutes(createActionRequest.countOrMinutes())
+			.description(createActionRequest.description())
+			.category(category)
+			.build();
+	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/domain/Action.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/domain/Action.java
@@ -37,7 +37,7 @@ public class Action extends DateEntity {
 	private String actionName;
 
 	@Column(name = "sets")
-	private int sets;
+	private Integer sets;
 
 	@Size(max = 45)
 	@Column(name = "count_or_minutes")

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/ActionDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/ActionDto.java
@@ -13,7 +13,7 @@ public record ActionDto(
 	@NotBlank(message = ErrorMessage.INVALID_VALUE)
 	String actionName,
 
-	int sets,
+	Integer sets,
 
 	String countOrMinutes,
 

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/ActionDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/ActionDto.java
@@ -1,17 +1,19 @@
 package site.coach_coach.coach_coach_server.action.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import site.coach_coach.coach_coach_server.action.domain.Action;
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 
 public record ActionDto(
 	@NotNull
 	Long actionId,
 
-	@NotNull
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
 	String actionName,
 
-	String sets,
+	int sets,
 
 	String countOrMinutes,
 

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionRequest.java
@@ -1,0 +1,16 @@
+package site.coach_coach.coach_coach_server.action.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+
+public record CreateActionRequest(
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
+	String actionName,
+
+	int sets,
+
+	String countOrMinutes,
+
+	String description
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionRequest.java
@@ -7,7 +7,7 @@ public record CreateActionRequest(
 	@NotBlank(message = ErrorMessage.INVALID_VALUE)
 	String actionName,
 
-	int sets,
+	Integer sets,
 
 	String countOrMinutes,
 

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionResponse.java
@@ -1,6 +1,0 @@
-package site.coach_coach.coach_coach_server.action.dto;
-
-public record CreateActionResponse(
-	Long actionId
-) {
-}

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionResponse.java
@@ -1,0 +1,6 @@
+package site.coach_coach.coach_coach_server.action.dto;
+
+public record CreateActionResponse(
+	Long actionId
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -1,0 +1,34 @@
+package site.coach_coach.coach_coach_server.action.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.coach_coach.coach_coach_server.action.domain.Action;
+import site.coach_coach.coach_coach_server.action.dto.CreateActionRequest;
+import site.coach_coach.coach_coach_server.action.repository.ActionRepository;
+import site.coach_coach.coach_coach_server.category.domain.Category;
+import site.coach_coach.coach_coach_server.category.exception.NotFoundCategoryException;
+import site.coach_coach.coach_coach_server.category.repository.CategoryRepository;
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+import site.coach_coach.coach_coach_server.routine.service.RoutineService;
+
+@Service
+@RequiredArgsConstructor
+public class ActionService {
+	private final RoutineService routineService;
+	private final CategoryRepository categoryRepository;
+	private final ActionRepository actionRepository;
+
+	@Transactional
+	public Long createAction(Long routineId, Long categoryId, Long userIdByJwt,
+		CreateActionRequest createActionRequest) {
+		routineService.validateAccessToRoutine(routineId, userIdByJwt);
+		Category category = categoryRepository.findById(categoryId)
+			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
+
+		Action action = Action.of(createActionRequest, category);
+
+		return actionRepository.save(action).getActionId();
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -24,7 +24,7 @@ public class ActionService {
 	public Long createAction(Long routineId, Long categoryId, Long userIdByJwt,
 		CreateActionRequest createActionRequest) {
 		routineService.validateAccessToRoutine(routineId, userIdByJwt);
-		Category category = categoryRepository.findById(categoryId)
+		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineId(categoryId, routineId)
 			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		Action action = Action.of(createActionRequest, category);


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 카테고리에 운동을 추가하는 API 구현
- 자신이 만든 루틴의 카테고리에만 운동을 추가할 수 있습니다.
- 코치는 매칭된 회원에게 만들어준 루틴의 카테고리에 운동을 추가할 수 있습니다.
- 운동 추가 전, 루틴과 카테고리의 접근 가능성과 존재 유무를 검증합니다.

### PR Point
- 루틴과 카테고리의 접근 가능성과 존재 유무 검증을 통해 예외처리가 적절히 되는지 확인해주세요!

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/fb02e8bc-3c9d-4028-b0b7-73399827a02c)|자신이 만든 루틴의 카테고리에 운동 추가 성공|
|![image](https://github.com/user-attachments/assets/f0732a5f-b2e2-4a3b-9ebc-45f373f76417)|코치가 매칭된 회원에게 운동 추가 성공|
|![image](https://github.com/user-attachments/assets/85030557-9f31-425d-b757-856eb3c08566)|자신이 만들지 않은 루틴에 접근 시 예외 처리(코치를 겸하고 있지 않은 경우)|
|<img width="484" alt="image" src="https://github.com/user-attachments/assets/1008c521-b8df-4436-ab0f-96c3bb41a21a">|자신이 만들지 않은 루틴에 접근 시 예외 처리(코치를 겸하고 있는 경우)|
|![image](https://github.com/user-attachments/assets/8a73875d-9c89-49e1-a539-08cd3d54bf1f)|일반 회원이 코치가 만들어준 루틴에 접근 시 예외 처리|
|![image](https://github.com/user-attachments/assets/ab98e56c-1b6b-47c2-9427-461e8e1c69a5)|존재하지 않는 루틴 접근 시 예외 처리|
|![image](https://github.com/user-attachments/assets/581211d1-8928-46f3-b07e-e0ad6d789742)|존재하지 않는 카테고리 접근 시 예외 처리|

### 논의 사항 (선택)

closed #179
