### PR TITLE
feat(action) : 운동 삭제 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
@@ -3,6 +3,7 @@ package site.coach_coach.coach_coach_server.action.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,5 +34,17 @@ public class ActionController {
 		Long actionId = actionService.createAction(routineId, categoryId, userIdByJwt, createActionRequest);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(new SuccessIdResponse(actionId));
+	}
+
+	@DeleteMapping("/v1/routines/{routineId}/{categoryId}/{actionId}")
+	public ResponseEntity<Void> deleteAction(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable(name = "routineId") Long routineId,
+		@PathVariable(name = "categoryId") Long categoryId,
+		@PathVariable(name = "actionId") Long actionId
+	) {
+		Long userIdByJwt = userDetails.getUserId();
+		actionService.deleteAction(routineId, categoryId, actionId, userIdByJwt);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/controller/ActionController.java
@@ -24,7 +24,7 @@ public class ActionController {
 	private final ActionService actionService;
 
 	@PostMapping("/v1/routines/{routineId}/{categoryId}")
-	public ResponseEntity<SuccessIdResponse> createAction(
+	public ResponseEntity<SuccessIdResponse> createActionIntoCategory(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable(name = "routineId") Long routineId,
 		@PathVariable(name = "categoryId") Long categoryId,
@@ -37,7 +37,7 @@ public class ActionController {
 	}
 
 	@DeleteMapping("/v1/routines/{routineId}/{categoryId}/{actionId}")
-	public ResponseEntity<Void> deleteAction(
+	public ResponseEntity<Void> deleteActionInCategory(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable(name = "routineId") Long routineId,
 		@PathVariable(name = "categoryId") Long categoryId,

--- a/src/main/java/site/coach_coach/coach_coach_server/action/exception/NotFoundActionException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/exception/NotFoundActionException.java
@@ -1,0 +1,9 @@
+package site.coach_coach.coach_coach_server.action.exception;
+
+import java.util.NoSuchElementException;
+
+public class NotFoundActionException extends NoSuchElementException {
+	public NotFoundActionException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -24,7 +24,7 @@ public class ActionService {
 	@Transactional
 	public Long createAction(Long routineId, Long categoryId, Long userIdByJwt,
 		CreateActionRequest createActionRequest) {
-		routineService.validateAccessToRoutine(routineId, userIdByJwt);
+		routineService.validateBeforeModifyRoutineDetail(routineId, userIdByJwt);
 		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineId(categoryId, routineId)
 			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
 
@@ -35,7 +35,7 @@ public class ActionService {
 
 	@Transactional
 	public void deleteAction(Long routineId, Long categoryId, Long actionId, Long userIdByJwt) {
-		routineService.validateAccessToRoutine(routineId, userIdByJwt);
+		routineService.validateBeforeModifyRoutineDetail(routineId, userIdByJwt);
 		categoryRepository.findByCategoryIdAndRoutine_RoutineId(categoryId, routineId)
 			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
 

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.action.domain.Action;
 import site.coach_coach.coach_coach_server.action.dto.CreateActionRequest;
+import site.coach_coach.coach_coach_server.action.exception.NotFoundActionException;
 import site.coach_coach.coach_coach_server.action.repository.ActionRepository;
 import site.coach_coach.coach_coach_server.category.domain.Category;
 import site.coach_coach.coach_coach_server.category.exception.NotFoundCategoryException;
@@ -30,5 +31,19 @@ public class ActionService {
 		Action action = Action.of(createActionRequest, category);
 
 		return actionRepository.save(action).getActionId();
+	}
+
+	@Transactional
+	public void deleteAction(Long routineId, Long categoryId, Long actionId, Long userIdByJwt) {
+		routineService.validateAccessToRoutine(routineId, userIdByJwt);
+		categoryRepository.findByCategoryIdAndRoutine_RoutineId(categoryId, routineId)
+			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
+
+		Boolean isExistsAction = actionRepository.existsById(actionId);
+		if (isExistsAction) {
+			actionRepository.deleteById(actionId);
+		} else {
+			throw new NotFoundActionException(ErrorMessage.NOT_FOUND_ACTION);
+		}
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -39,8 +39,7 @@ public class ActionService {
 		categoryRepository.findByCategoryIdAndRoutine_RoutineId(categoryId, routineId)
 			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
 
-		Boolean isExistsAction = actionRepository.existsById(actionId);
-		if (isExistsAction) {
+		if (actionRepository.existsById(actionId)) {
 			actionRepository.deleteById(actionId);
 		} else {
 			throw new NotFoundActionException(ErrorMessage.NOT_FOUND_ACTION);

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -46,7 +46,7 @@ public class CategoryService {
 	}
 
 	@Transactional
-	public Category changeIsCompleted(Long categoryId, Long routineId, Boolean inputIsCompleted) {
+	public Category updateCategoryCompletionStatus(Long categoryId, Long routineId, Boolean inputIsCompleted) {
 		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineId(categoryId, routineId)
 			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
 

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -22,7 +22,7 @@ public class CategoryService {
 
 	@Transactional
 	public Long createCategory(CreateCategoryRequest createCategoryRequest, Long routineId, Long userIdByJwt) {
-		Routine routine = routineService.validateAccessToRoutine(routineId, userIdByJwt);
+		Routine routine = routineService.validateBeforeModifyRoutineDetail(routineId, userIdByJwt);
 
 		Category category = Category.builder()
 			.routine(routine)
@@ -35,7 +35,7 @@ public class CategoryService {
 
 	@Transactional
 	public void deleteCategory(Long routineId, Long categoryId, Long userIdByJwt) {
-		routineService.validateAccessToRoutine(routineId, userIdByJwt);
+		routineService.validateBeforeModifyRoutineDetail(routineId, userIdByJwt);
 
 		Boolean isExistCategory = categoryRepository.existsById(categoryId);
 		if (isExistCategory) {

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -9,6 +9,8 @@ import site.coach_coach.coach_coach_server.category.dto.CreateCategoryRequest;
 import site.coach_coach.coach_coach_server.category.exception.NotFoundCategoryException;
 import site.coach_coach.coach_coach_server.category.repository.CategoryRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+import site.coach_coach.coach_coach_server.completedcategory.exception.DuplicateCompletedCategoryException;
+import site.coach_coach.coach_coach_server.completedcategory.exception.NotFoundCompletedCategoryException;
 import site.coach_coach.coach_coach_server.routine.domain.Routine;
 import site.coach_coach.coach_coach_server.routine.service.RoutineService;
 
@@ -44,9 +46,17 @@ public class CategoryService {
 	}
 
 	@Transactional
-	public Category changeIsCompleted(Long categoryId, Long routineId) {
+	public Category changeIsCompleted(Long categoryId, Long routineId, Boolean inputIsCompleted) {
 		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineId(categoryId, routineId)
 			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
+
+		if (category.getIsCompleted().equals(inputIsCompleted)) {
+			if (inputIsCompleted) {
+				throw new DuplicateCompletedCategoryException(ErrorMessage.DUPLICATE_COMPLETED_CATEGORY);
+			} else {
+				throw new NotFoundCompletedCategoryException(ErrorMessage.NOT_FOUND_COMPLETED_CATEGORY);
+			}
+		}
 
 		// Dirty Checking
 		category.setIsCompleted(!category.getIsCompleted());

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -34,6 +34,7 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_ACTION = "존재하지 않는 운동입니다.";
 	public static final String NOT_FOUND_RECORD = "존재하지 않는 기록입니다.";
 	public static final String NOT_FOUND_NOTIFICATION = "해당 알림을 찾을 수 없습니다.";
+	public static final String NOT_FOUND_COMPLETED_CATEGORY = "존재하지 않는 카테고리입니다.";
 
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
@@ -42,6 +43,7 @@ public final class ErrorMessage {
 	public static final String NOT_MATCHING = "매칭되지 않은 대상입니다.";
 	public static final String NOT_FOUND_MATCHING = "문의 회원이 아닙니다.";
 	public static final String DUPLICATE_MATCHING = "이미 매칭된 회원입니다.";
+	public static final String DUPLICATE_COMPLETED_CATEGORY = "이미 완료한 카테고리입니다.";
 
 	public static final String NOT_FOUND_SPORTS = "종목 정보를 찾을 수 없습니다.";
 	public static final String SERVER_SHUTDOWN = "서버가 종료되었습니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -31,6 +31,7 @@ public final class ErrorMessage {
 	public static final String NOT_FOUND_TOKEN = "토큰이 존재하지 않습니다.";
 	public static final String NOT_FOUND_ROUTINE = "존재하지 않는 루틴입니다.";
 	public static final String NOT_FOUND_CATEGORY = "존재하지 않는 카테고리입니다.";
+	public static final String NOT_FOUND_ACTION = "존재하지 않는 운동입니다.";
 	public static final String NOT_FOUND_RECORD = "존재하지 않는 기록입니다.";
 	public static final String NOT_FOUND_NOTIFICATION = "해당 알림을 찾을 수 없습니다.";
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
@@ -14,6 +14,7 @@ public enum SuccessMessage {
 	CREATE_ROUTINE_SUCCESS("루틴 추가 성공"),
 	DELETE_ROUTINE_SUCCESS("루틴 삭제 성공"),
 	DELETE_CATEGORY_SUCCESS("카테고리 삭제 성공"),
+	DELETE_ACTION_SUCCESS("운동 삭제 성공"),
 	UPDATE_COACH_PROFILE_SUCCESS("업로드 성공"),
 	DELETE_NOTIFICATION_SUCCESS("알림 삭제 성공"),
 	MATCH_MEMBER_SUCCESS("관리 회원에 등록되었습니다."),

--- a/src/main/java/site/coach_coach/coach_coach_server/completedcategory/exception/DuplicateCompletedCategoryException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/completedcategory/exception/DuplicateCompletedCategoryException.java
@@ -1,8 +1,8 @@
 package site.coach_coach.coach_coach_server.completedcategory.exception;
 
-import org.springframework.dao.DuplicateKeyException;
+import site.coach_coach.coach_coach_server.userrecord.exception.DuplicateRecordException;
 
-public class DuplicateCompletedCategoryException extends DuplicateKeyException {
+public class DuplicateCompletedCategoryException extends DuplicateRecordException {
 	public DuplicateCompletedCategoryException(String message) {
 		super(message);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
@@ -20,7 +20,7 @@ public class CompletedCategoryService {
 
 	@Transactional
 	public Long createCompletedCategory(Long routineId, Long categoryId, Long userIdByJwt) {
-		Category category = categoryService.changeIsCompleted(categoryId, routineId);
+		Category category = categoryService.changeIsCompleted(categoryId, routineId, true);
 		UserRecord userRecord = userRecordService.getUserRecordForCompleteCategory(userIdByJwt);
 		CompletedCategory completedCategory = CompletedCategory.builder()
 			.userRecord(userRecord)
@@ -33,7 +33,7 @@ public class CompletedCategoryService {
 
 	@Transactional
 	public void deleteCompletedCategory(Long routineId, Long categoryId, Long userIdByJwt) {
-		Category category = categoryService.changeIsCompleted(categoryId, routineId);
+		Category category = categoryService.changeIsCompleted(categoryId, routineId, false);
 		UserRecord userRecord = userRecordService.getUserRecordForCompleteCategory(userIdByJwt);
 		completedCategoryRepository.deleteByUserRecord_UserRecordIdAndCategory_CategoryId(
 			userRecord.getUserRecordId(), category.getCategoryId());

--- a/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
@@ -20,7 +20,7 @@ public class CompletedCategoryService {
 
 	@Transactional
 	public Long createCompletedCategory(Long routineId, Long categoryId, Long userIdByJwt) {
-		Category category = categoryService.changeIsCompleted(categoryId, routineId, true);
+		Category category = categoryService.updateCategoryCompletionStatus(categoryId, routineId, true);
 		UserRecord userRecord = userRecordService.getUserRecordForCompleteCategory(userIdByJwt);
 		CompletedCategory completedCategory = CompletedCategory.builder()
 			.userRecord(userRecord)
@@ -33,7 +33,7 @@ public class CompletedCategoryService {
 
 	@Transactional
 	public void deleteCompletedCategory(Long routineId, Long categoryId, Long userIdByJwt) {
-		Category category = categoryService.changeIsCompleted(categoryId, routineId, false);
+		Category category = categoryService.updateCategoryCompletionStatus(categoryId, routineId, false);
 		UserRecord userRecord = userRecordService.getUserRecordForCompleteCategory(userIdByJwt);
 		completedCategoryRepository.deleteByUserRecord_UserRecordIdAndCategory_CategoryId(
 			userRecord.getUserRecordId(), category.getCategoryId());

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -79,7 +79,7 @@ public class RoutineController {
 		@PathVariable(name = "routineId") Long routineId
 	) {
 		Long userIdByJwt = userDetails.getUserId();
-		routineService.validateAndDeleteRoutine(routineId, userIdByJwt);
+		routineService.deleteRoutine(routineId, userIdByJwt);
 		return ResponseEntity.ok(
 			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_ROUTINE_SUCCESS.getMessage()));
 	}
@@ -92,7 +92,7 @@ public class RoutineController {
 	) {
 		Long userIdByJwt = userDetails.getUserId();
 
-		RoutineResponse routineResponse = routineService.getRoutineWithCategoriesAndActions(routineId,
+		RoutineResponse routineResponse = routineService.getRoutineDetail(routineId,
 			userIdByJwt, userIdParam);
 		return ResponseEntity.ok(routineResponse);
 	}

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -212,7 +212,7 @@ public class RoutineControllerTest {
 	@DisplayName("루틴 삭제 성공 테스트")
 	public void deleteRoutineSuccessTest() throws Exception {
 
-		doNothing().when(routineService).validateAndDeleteRoutine(1L, userIdByJwt);
+		doNothing().when(routineService).deleteRoutine(1L, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/1").with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isOk())
@@ -228,7 +228,7 @@ public class RoutineControllerTest {
 		// Given
 		Long routineId = 0L;
 		doThrow(new NoExistRoutineException(ErrorMessage.NOT_FOUND_ROUTINE)).when(routineService)
-			.validateAndDeleteRoutine(anyLong(), anyLong());
+			.deleteRoutine(anyLong(), anyLong());
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isNotFound())
@@ -245,7 +245,7 @@ public class RoutineControllerTest {
 		Long routineId = 0L;
 
 		doThrow(new AccessDeniedException()).when(routineService)
-			.validateAndDeleteRoutine(routineId, userIdByJwt);
+			.deleteRoutine(routineId, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/" + routineId).with(csrf()))
 			.andExpect(MockMvcResultMatchers.status().isForbidden())
@@ -268,7 +268,7 @@ public class RoutineControllerTest {
 		categoryList.add(categoryDto);
 		RoutineResponse routineResponse = new RoutineResponse("routineName", categoryList);
 
-		when(routineService.getRoutineWithCategoriesAndActions(anyLong(), anyLong(), anyLong())).thenReturn(
+		when(routineService.getRoutineDetail(anyLong(), anyLong(), anyLong())).thenReturn(
 			routineResponse);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routines/" + routine.routineId())


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 운동을 삭제하는 API 구현
- 자신이 만든 루틴의 카테고리에서 운동을 삭제할 수 있습니다.
- 코치는 매칭된 회원에게 만들어 준 루틴의 카테고리에서 운동을 삭제할 수 있습니다.
- 운동 삭제 시, 루틴 접근성을 검증합니다.
  - 검증된 루틴 안에 삭제하려는 운동이 포함된 카테고리 존재하는지 확인합니다.
  - 삭제하려는 운동의 존재하는지 확인합니다.

### PR Point
- 중복되는 검증 코드를 정리하였습니다.
- 적절하지 않은 메서드명을 의미가 잘 전달되도록 변경하였습니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|<img width="693" alt="image" src="https://github.com/user-attachments/assets/4cdd4e3d-620a-438a-ae67-6eb3169375f7">|자신이 만든 루틴에서 운동 삭제 성공|
|<img width="697" alt="image" src="https://github.com/user-attachments/assets/513a6a7a-b201-4b92-9473-1ca72b5db8a4">|코치가 회원에게 만들어준 루틴에서 운동 삭제 성공|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/d0fbbb27-cb29-4597-997b-4fac97eb83db">|일반 회원이 코치가 만들어준 루틴에 접근 시, 예외 처리|
|<img width="503" alt="image" src="https://github.com/user-attachments/assets/0444e1d2-b25a-46af-b1b6-413fab31e99b">|자신이 만들지 않은 루틴에 접근 시, 예외 처리|
|<img width="512" alt="image" src="https://github.com/user-attachments/assets/44ad4cda-ec7d-49bd-9bfa-6eaabe1eada6">|존재하지 않는 루틴이 없을 시 예외 처리|
|<img width="466" alt="image" src="https://github.com/user-attachments/assets/c9664776-c209-4b73-a848-da786793d0c7">|루틴 내 카테고리가 없을 시 예외처리|
|<img width="697" alt="image" src="https://github.com/user-attachments/assets/5889d76e-ec32-4a52-9739-9736c9bdad35">|삭제하려는 운동이 없을 시 예외 처리|

### 논의 사항 (선택)

closed #184
