### PR TITLE
feat(coach) : 리뷰 등록 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -23,6 +23,7 @@ import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
 import site.coach_coach.coach_coach_server.coach.dto.CoachRequest;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingCoachResponseDto;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingUserResponseDto;
+import site.coach_coach.coach_coach_server.coach.dto.ReviewRequestDto;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
 import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
 import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
@@ -153,5 +154,18 @@ public class CoachController {
 		List<MatchingCoachResponseDto> matchingCoaches = coachService.getMatchingCoachesByUserId(userId);
 
 		return ResponseEntity.ok(matchingCoaches);
+	}
+
+	@PostMapping("/v1/coaches/{coachId}/reviews")
+	public ResponseEntity<SuccessResponse> addReview(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable Long coachId,
+		@RequestBody @Valid ReviewRequestDto requestDto) {
+
+		Long userId = userDetails.getUserId();
+		coachService.addReview(userId, coachId, requestDto);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(new SuccessResponse(HttpStatus.CREATED.value(), SuccessMessage.CREATE_REVIEW_SUCCESS.getMessage()));
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/ReviewRequestDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/ReviewRequestDto.java
@@ -1,0 +1,12 @@
+package site.coach_coach.coach_coach_server.coach.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record ReviewRequestDto(
+	String contents,
+
+	@Min(1) @Max(5)
+	int stars
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/exception/DuplicateReviewException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/exception/DuplicateReviewException.java
@@ -1,0 +1,11 @@
+package site.coach_coach.coach_coach_server.coach.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DuplicateReviewException extends RuntimeException {
+	public DuplicateReviewException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -19,8 +19,10 @@ import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
 import site.coach_coach.coach_coach_server.coach.dto.CoachRequest;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingCoachResponseDto;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingUserResponseDto;
+import site.coach_coach.coach_coach_server.coach.dto.ReviewRequestDto;
 import site.coach_coach.coach_coach_server.coach.exception.AlreadyMatchedException;
 import site.coach_coach.coach_coach_server.coach.exception.DuplicateContactException;
+import site.coach_coach.coach_coach_server.coach.exception.DuplicateReviewException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundCoachException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundMatchingException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundPageException;
@@ -150,6 +152,12 @@ public class CoachService {
 	}
 
 	@Transactional(readOnly = true)
+	public User getUserById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(InvalidUserException::new);
+	}
+
+	@Transactional(readOnly = true)
 	public Coach getCoachById(Long coachId) {
 		return coachRepository.findById(coachId)
 			.orElseThrow(() -> new NotFoundCoachException(ErrorMessage.NOT_FOUND_COACH));
@@ -271,6 +279,22 @@ public class CoachService {
 			user.getProfileImageUrl(),
 			matching.getIsMatching()
 		);
+	}
+
+	@Transactional
+	public void addReview(Long userId, Long coachId, ReviewRequestDto requestDto) {
+		User user = getUserById(userId);
+		Coach coach = getCoachById(coachId);
+
+		reviewRepository.findByUser_UserIdAndCoach_CoachId(userId, coachId)
+			.ifPresent(review -> {
+				throw new DuplicateReviewException(ErrorMessage.ALREADY_EXISTS_REVIEW);
+			});
+
+		Review review = new Review(null, coach, user, requestDto.contents(), requestDto.stars());
+
+		reviewRepository.save(review);
+		notificationService.createNotification(user.getUserId(), coachId, RelationFunctionEnum.review);
 	}
 
 	public List<MatchingCoachResponseDto> getMatchingCoachesByUserId(Long userId) {

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -48,7 +48,7 @@ public final class ErrorMessage {
 	public static final String INVALID_QUERY_PARAMETER = "잘못된 쿼리 파라미터입니다.";
 	public static final String DUPLICATE_CONTACT = "이미 해당 코치에 대한 문의 요청이 존재합니다.";
 	public static final String DUPLICATE_RECORD = "입력하신 날짜에 대한 기록이 이미 존재합니다.";
-
+	public static final String ALREADY_EXISTS_REVIEW = "이미 해당 코치에 대한 리뷰가 존재합니다.";
 	public static final String CONVERT_FAIL = "파일 변환에 실패했습니다.";
 	public static final String INVALID_FILE_EXTENSION = "허용된 파일 확장자가 아닙니다.";
 	public static final String INVALID_FILE_NAME = "유효하지 않은 파일 이름입니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/SuccessMessage.java
@@ -20,7 +20,8 @@ public enum SuccessMessage {
 	CREATE_CONTACT_SUCCESS("문의 회원으로 등록되었습니다."),
 	CREATE_LIKE_SUCCESS("관심 코치에 등록되었습니다."),
 	DELETE_LIKE_SUCCESS("관심 코치 취소 되었습니다."),
-	DELETE_MATCHING("매칭 삭제 성공");
+	DELETE_MATCHING("매칭 삭제 성공"),
+	CREATE_REVIEW_SUCCESS("리뷰가 등록되었습니다.");
 
 	private final String message;
 

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import site.coach_coach.coach_coach_server.coach.exception.AlreadyMatchedException;
 import site.coach_coach.coach_coach_server.coach.exception.DuplicateContactException;
+import site.coach_coach.coach_coach_server.coach.exception.DuplicateReviewException;
 import site.coach_coach.coach_coach_server.coach.exception.InvalidQueryParameterException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundMatchingException;
 import site.coach_coach.coach_coach_server.coach.exception.NotFoundPageException;
@@ -166,6 +167,12 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(DuplicateContactException.class)
 	public ResponseEntity<ErrorResponse> handleDuplicateContactException(DuplicateContactException ex) {
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+			.body(new ErrorResponse(HttpStatus.CONFLICT.value(), ex.getMessage()));
+	}
+
+	@ExceptionHandler(DuplicateReviewException.class)
+	public ResponseEntity<ErrorResponse> handleDuplicateReviewException(DuplicateReviewException ex) {
 		return ResponseEntity.status(HttpStatus.CONFLICT)
 			.body(new ErrorResponse(HttpStatus.CONFLICT.value(), ex.getMessage()));
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/review/repository/ReviewRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package site.coach_coach.coach_coach_server.review.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,7 @@ import site.coach_coach.coach_coach_server.review.domain.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 	List<Review> findByCoach_CoachId(Long coachId);
+
+	Optional<Review> findByUser_UserIdAndCoach_CoachId(Long userId, Long coachId);
+
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 리뷰 등록 기능을 구현했습니다.
  - 사용자가 코치에 대한 리뷰를 작성할 수 있는 기능을 추가했습니다. 해당 리뷰는 reviews 테이블에 저장됩니다.
  - 유저와 코치 정보를 조회하는 중복된 코드를 제거하기 위해, findUserById와 findCoachById 메서드를 분리했습니다.
  - 동일한 유저가 동일한 코치에 대해 중복된 리뷰를 작성하지 못하도록 검증 로직을 추가했습니다.
  -  존재하지 않는 코치에 대한 리뷰 작성 시, 404 Not Found 예외를 처리했습니다. 이에 따라 잘못된 요청에 대해 명확한 응답을 제공할 수 있습니다.
  - 등록 성공 시 코치에게 알림 메세지가 전달됩니다.
 
### PR Point
- 정상적으로 등록 성공 시 리뷰가 저장과 함께 알림이 전달되고, 201을 반환합니다.
- 존재하지 않는 코치에 대한 리뷰 작성 시, 404 Not Found 예외를 처리했습니다. 
- 이미 작성한 리뷰가 존재할 경우 409 CONFLICT 예외를 처리했습니다.

### 📸 스크린샷
|설명|사진|
|---|---|
|![image](https://github.com/user-attachments/assets/9aa1a6f9-4c73-4780-abf0-4d0dd75e81af)| 등록 성공 |
|![image](https://github.com/user-attachments/assets/b741ffcb-2dc6-46dd-a66d-0fa65e881776)| 존재하지 않는 `coachId` 요청 시 | 
|![image](https://github.com/user-attachments/assets/192ee430-c04d-450a-9aa9-b7679e790f81)| 해당 코치에 대해 이미 작성한 리뷰가 있을 때 |

### 논의 사항 (선택)
- 논의할 사항이 있다면 적어주세요.

closed #198