### PR TITLE
feat(category) : 카테고리 수정 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/category/controller/CategoryController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/controller/CategoryController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.category.dto.CreateCategoryRequest;
 import site.coach_coach.coach_coach_server.category.dto.CreateCategoryResponse;
+import site.coach_coach.coach_coach_server.category.dto.UpdateCategoryInfoRequest;
 import site.coach_coach.coach_coach_server.category.service.CategoryService;
 import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
 import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
@@ -47,5 +49,17 @@ public class CategoryController {
 		categoryService.deleteCategory(routineId, categoryId, userIdByJWt);
 		return ResponseEntity.ok(
 			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_CATEGORY_SUCCESS.getMessage()));
+	}
+
+	@PatchMapping("/v1/categories/{categoryId}")
+	public ResponseEntity<SuccessResponse> updateCategory(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable(name = "categoryId") Long categoryId,
+		@RequestBody @Valid UpdateCategoryInfoRequest updateCategoryInfoRequest
+	) {
+		Long userIdByJwt = userDetails.getUserId();
+		categoryService.updateCategory(updateCategoryInfoRequest, categoryId, userIdByJwt);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
@@ -60,4 +60,7 @@ public class Category extends DateEntity {
 	@OneToOne(mappedBy = "category")
 	private CompletedCategory completedCategory;
 
+	public void updateCategoryInfo(String categoryName) {
+		this.categoryName = categoryName;
+	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/category/dto/UpdateCategoryInfoRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/dto/UpdateCategoryInfoRequest.java
@@ -1,0 +1,12 @@
+package site.coach_coach.coach_coach_server.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+
+public record UpdateCategoryInfoRequest(
+	@NotBlank(message = ErrorMessage.INVALID_VALUE)
+	@Size(max = 45)
+	String categoryName
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.category.domain.Category;
 import site.coach_coach.coach_coach_server.category.dto.CreateCategoryRequest;
+import site.coach_coach.coach_coach_server.category.dto.UpdateCategoryInfoRequest;
 import site.coach_coach.coach_coach_server.category.exception.NotFoundCategoryException;
 import site.coach_coach.coach_coach_server.category.repository.CategoryRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
@@ -61,5 +62,14 @@ public class CategoryService {
 		// Dirty Checking
 		category.setIsCompleted(!category.getIsCompleted());
 		return category;
+	}
+
+	public void updateCategory(UpdateCategoryInfoRequest updateCategoryInfoRequest, Long categoryId, Long userIdByJwt) {
+		Category category = categoryRepository.findById(categoryId)
+			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));
+
+		routineService.validateBeforeModifyRoutineDetail(category.getRoutine().getRoutineId(), userIdByJwt);
+
+		category.updateCategoryInfo(updateCategoryInfoRequest.categoryName());
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -64,6 +64,7 @@ public class CategoryService {
 		return category;
 	}
 
+	@Transactional
 	public void updateCategory(UpdateCategoryInfoRequest updateCategoryInfoRequest, Long categoryId, Long userIdByJwt) {
 		Category category = categoryRepository.findById(categoryId)
 			.orElseThrow(() -> new NotFoundCategoryException(ErrorMessage.NOT_FOUND_CATEGORY));


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 카테고리 정보 수정 API 구현
- 카테고리 이름 수정 가능
- 카테고리 접근 가능 검증
  - 자신이 만들지 않은 루틴의 카테고리 접근 시 예외처리
  - 코치가 만들지 않은 루틴의 카테고리에 코치가 접근 시 예외처리
- 입력받은 카테고리 이름값 검증

### PR Point
- 현재는 변경될 URL로 코드를 작성했습니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|<img width="693" alt="image" src="https://github.com/user-attachments/assets/68db08fb-c71e-46eb-b43e-17856cd3b753">|자신이 만든 루틴의 카테고리 수정 성공|
|<img width="701" alt="image" src="https://github.com/user-attachments/assets/c7e56673-35ea-4e49-bce1-7cd223ae3b3d">|코치가 회원에게 만들어준 루틴의 카테고리 수정 성공|
|<img width="691" alt="image" src="https://github.com/user-attachments/assets/e880e7ee-c297-47f4-adf8-b8479a5af8c5">|자신이 만들지 않은 루틴 접근 시 예외처리|
|<img width="470" alt="image" src="https://github.com/user-attachments/assets/bef58645-8625-4c23-87eb-b29a39f50df4">|코치가 만들지 않은 루틴 접근 시 예외처리|
|<img width="453" alt="image" src="https://github.com/user-attachments/assets/ad4dcccf-9777-483b-805c-adfae16526fa">|입력받은 카테고리 이름값 검증|

### 논의 사항 (선택)

closed #212
