### PR TITLE
refactor(action) : countOrMinutes 데이터 분리

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/action/domain/Action.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/domain/Action.java
@@ -42,9 +42,13 @@ public class Action extends DateEntity {
 	@Column(name = "sets")
 	private Integer sets;
 
-	@Size(max = 45)
-	@Column(name = "count_or_minutes")
-	private String countOrMinutes;
+	@Positive
+	@Column(name = "counts")
+	private Integer counts;
+
+	@Positive
+	@Column(name = "minutes")
+	private Integer minutes;
 
 	@Size(max = 200)
 	@Column(name = "description")
@@ -58,7 +62,8 @@ public class Action extends DateEntity {
 		return Action.builder()
 			.actionName(createActionRequest.actionName())
 			.sets(createActionRequest.sets())
-			.countOrMinutes(createActionRequest.countOrMinutes())
+			.counts(createActionRequest.counts())
+			.minutes(createActionRequest.minutes())
 			.description(createActionRequest.description())
 			.category(category)
 			.build();
@@ -67,7 +72,8 @@ public class Action extends DateEntity {
 	public void updateActionInfo(UpdateActionInfoRequest updateActionInfoRequest) {
 		this.actionName = updateActionInfoRequest.actionName();
 		this.sets = updateActionInfoRequest.sets();
-		this.countOrMinutes = updateActionInfoRequest.countOrMinutes();
+		this.counts = updateActionInfoRequest.counts();
+		this.minutes = updateActionInfoRequest.minutes();
 		this.description = updateActionInfoRequest.description();
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/ActionDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/ActionDto.java
@@ -1,23 +1,13 @@
 package site.coach_coach.coach_coach_server.action.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import site.coach_coach.coach_coach_server.action.domain.Action;
-import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 
 public record ActionDto(
-	@NotNull
 	Long actionId,
-
-	@NotBlank(message = ErrorMessage.INVALID_VALUE)
 	String actionName,
-
 	Integer sets,
-
-	String countOrMinutes,
-
-	@Size(max = 200)
+	Integer counts,
+	Integer minutes,
 	String description
 ) {
 	public static ActionDto from(Action action) {
@@ -25,7 +15,8 @@ public record ActionDto(
 			action.getActionId(),
 			action.getActionName(),
 			action.getSets(),
-			action.getCountOrMinutes(),
+			action.getCounts(),
+			action.getMinutes(),
 			action.getDescription()
 		);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/CreateActionRequest.java
@@ -1,6 +1,7 @@
 package site.coach_coach.coach_coach_server.action.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 
 public record CreateActionRequest(
@@ -8,9 +9,10 @@ public record CreateActionRequest(
 	String actionName,
 
 	Integer sets,
+	Integer counts,
+	Integer minutes,
 
-	String countOrMinutes,
-
+	@Size(max = 200)
 	String description
 ) {
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/dto/UpdateActionInfoRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/dto/UpdateActionInfoRequest.java
@@ -10,9 +10,8 @@ public record UpdateActionInfoRequest(
 	String actionName,
 
 	Integer sets,
-
-	@Size(max = 45)
-	String countOrMinutes,
+	Integer counts,
+	Integer minutes,
 
 	@Size(max = 200)
 	String description

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -254,7 +254,7 @@ public class RoutineControllerTest {
 	public void getRoutineSuccessTest() throws Exception {
 		// Given
 		Long userIdParam = 1L;
-		ActionDto actionDto = new ActionDto(1L, "actionName", 5, "10", "description");
+		ActionDto actionDto = new ActionDto(1L, "actionName", 5, 10, 5, "description");
 		List<ActionDto> actionList = new ArrayList<>();
 		actionList.add(actionDto);
 		CategoryDto categoryDto = new CategoryDto(1L, "categoryName", false, actionList);


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- actions Entity의 countOrMinutes 데이터를 counts와 minutes 로 분리하였습니다.
- 데이터 오염을 예방하기 위해 기존의 String 타입에서 Integer 타입의 데이터로 변경하였습니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|<img width="698" alt="image" src="https://github.com/user-attachments/assets/609c05ea-5c99-407a-8966-72fba7f9a10b">|counts와 minutes로 변경 후, 운동 추가 성공|
|<img width="690" alt="image" src="https://github.com/user-attachments/assets/a945e066-71f0-4797-9061-05db8aef0508">|루틴 개별 조회 시, counts와 minutes 조회 가능|

closed #247
