### PR TITLE
refactor(category) : 자정마다 is_completed 값 초기화 기능 추가

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/CoachCoachServerApplication.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/CoachCoachServerApplication.java
@@ -3,12 +3,14 @@ package site.coach_coach.coach_coach_server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import io.sentry.Sentry;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class CoachCoachServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
@@ -3,9 +3,16 @@ package site.coach_coach.coach_coach_server.category.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import site.coach_coach.coach_coach_server.category.domain.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 	Optional<Category> findByCategoryIdAndRoutine_RoutineId(Long categoryId, Long routineId);
+
+	@Modifying
+	@Query("UPDATE Category c SET c.isCompleted = :falseStatus")
+	void resetIsCompleted(@Param("falseStatus") Boolean falseStatus);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -1,9 +1,11 @@
 package site.coach_coach.coach_coach_server.category.service;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import site.coach_coach.coach_coach_server.category.domain.Category;
 import site.coach_coach.coach_coach_server.category.dto.CreateCategoryRequest;
 import site.coach_coach.coach_coach_server.category.dto.UpdateCategoryInfoRequest;
@@ -14,6 +16,7 @@ import site.coach_coach.coach_coach_server.routine.domain.Routine;
 import site.coach_coach.coach_coach_server.routine.service.RoutineService;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class CategoryService {
 	private final CategoryRepository categoryRepository;
@@ -52,5 +55,12 @@ public class CategoryService {
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 
 		category.updateCategoryInfo(updateCategoryInfoRequest.categoryName());
+	}
+
+	@Transactional
+	@Scheduled(cron = "0 0 15 * * *")
+	public void resetIsCompleted() {
+		log.info("All 'IsCompleted' has been reset.");
+		categoryRepository.resetIsCompleted(false);
 	}
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- Scheduler 라이브러리를 사용하여 자정마다 모든 카테고리의 완료상태를 초기화 하는 메서드를 추가하였습니다.
- 해당 매서드가 실행되면 "All 'IsCompleted' has been reset." log가 출력됩니다

### 📸 스크린샷
| 사진 | 설명 |
|---|---|
|![image](https://github.com/user-attachments/assets/8c46b31c-65e6-4fa5-a232-9dfdd710e60e)|record_date만 Asia/Seoul 타임존으로 계산된 일자 정상 저장|

closed #258
