### PR TITLE
refactor(coach) : 코치 본인에 대한 요청 처리

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -26,6 +26,7 @@ import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
 import site.coach_coach.coach_coach_server.common.exception.AccessDeniedException;
 import site.coach_coach.coach_coach_server.common.exception.DuplicateValueException;
 import site.coach_coach.coach_coach_server.common.exception.NotFoundException;
+import site.coach_coach.coach_coach_server.common.exception.SelfRequestNotAllowedException;
 import site.coach_coach.coach_coach_server.common.exception.UserNotFoundException;
 import site.coach_coach.coach_coach_server.like.domain.UserCoachLike;
 import site.coach_coach.coach_coach_server.like.repository.UserCoachLikeRepository;
@@ -122,6 +123,10 @@ public class CoachService {
 	public void contactCoach(User user, Long coachId) {
 		Coach coach = coachRepository.findById(coachId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_COACH));
+
+		if (user.getUserId().equals(coach.getUser().getUserId())) {
+			throw new SelfRequestNotAllowedException(ErrorMessage.CANNOT_CONTACT_SELF);
+		}
 
 		if (matchingRepository.existsByUserUserIdAndCoachCoachId(user.getUserId(), coachId)) {
 			throw new DuplicateValueException(ErrorMessage.DUPLICATE_CONTACT);
@@ -239,6 +244,10 @@ public class CoachService {
 
 		Coach coach = coachRepository.findById(coachId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_COACH));
+
+		if (userId.equals(coach.getUser().getUserId())) {
+			throw new SelfRequestNotAllowedException(ErrorMessage.CANNOT_LIKE_SELF);
+		}
 
 		if (!userCoachLikeRepository.existsByUser_UserIdAndCoach_CoachId(userId, coachId)) {
 			userCoachLikeRepository.save(new UserCoachLike(null, user, coach));
@@ -413,6 +422,10 @@ public class CoachService {
 	public void updateMatchingStatus(Long coachUserId, Long userId) {
 		Coach coach = coachRepository.findByUser_UserId(coachUserId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_COACH));
+
+		if (coachUserId.equals(userId)) {
+			throw new SelfRequestNotAllowedException(ErrorMessage.CANNOT_MATCHING_SELF);
+		}
 
 		Matching matching = matchingRepository.findByUser_UserIdAndCoach_CoachId(userId, coach.getCoachId())
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CONTACT));

--- a/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/constants/ErrorMessage.java
@@ -39,6 +39,9 @@ public final class ErrorMessage {
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 
+	public static final String CANNOT_CONTACT_SELF = "자기 자신에게는 문의할 수 없습니다.";
+	public static final String CANNOT_MATCHING_SELF = "자기 자신을 매칭 회원으로 등록할 수 없습니다.";
+	public static final String CANNOT_LIKE_SELF = "자기 자신을 관심 코치로 등록할 수 없습니다.";
 	public static final String NOT_FOUND_MATCHING = "매칭되지 않은 대상입니다.";
 	public static final String NOT_FOUND_CONTACT = "문의 회원이 아닙니다.";
 	public static final String DUPLICATE_MATCHING = "이미 매칭된 회원입니다.";

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/GlobalExceptionHandler.java
@@ -92,6 +92,12 @@ public class GlobalExceptionHandler {
 			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ErrorMessage.INVALID_VALUE));
 	}
 
+	@ExceptionHandler(SelfRequestNotAllowedException.class)
+	public ResponseEntity<ErrorResponse> handleSelfRequestNotAllowedException(SelfRequestNotAllowedException ex) {
+		return ResponseEntity.status(HttpStatus.FORBIDDEN)
+			.body(new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
+	}
+
 	@ExceptionHandler(InvalidInputException.class)
 	public ResponseEntity<ErrorResponse> handleInvalidInputException(InvalidInputException ex) {
 		log.error("Handled exception: [{}] - {}", ex.getClass().getSimpleName(), ex.getMessage());

--- a/src/main/java/site/coach_coach/coach_coach_server/common/exception/SelfRequestNotAllowedException.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/exception/SelfRequestNotAllowedException.java
@@ -1,0 +1,7 @@
+package site.coach_coach.coach_coach_server.common.exception;
+
+public class SelfRequestNotAllowedException extends RuntimeException {
+	public SelfRequestNotAllowedException(String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 자기 매칭 방지 (updateMatchingStatus)
  - 사용자가 자신과 매칭 상태를 업데이트하지 못하도록 체크하는 로직을 추가했습니다.
  - 사용자가 자신의 코치 프로필과 매칭하려고 시도할 경우, 403 예외가 발생합니다.
- 자기 문의 방지 (contactCoach)
  - 사용자가 자신에게 문의하지 못하도록 체크하는 로직을 추가했습니다.
  - 사용자가 이를 시도할 경우, 403 예외가 발생합니다.
- 자기 좋아요 방지 (addCoachToFavorites)
  - 사용자가 자신의 코치 프로필을 좋아요 목록에 추가하지 못하도록 체크하는 로직을 추가했습니다.
  - 사용자가 이를 시도할 경우, 403 예외가 발생합니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/5a7af174-4239-4b9c-9906-8fc52376bde6)| 자신의 id 값으로 문의 요청을 했을 경우 | 
|![image](https://github.com/user-attachments/assets/c3ba0413-1f04-4a58-bf7b-e7e75ba8eb26)| 자신의 id 값으로 매칭 등록을 했을 경우 | 
|![image](https://github.com/user-attachments/assets/75e88e1c-beea-44aa-a12f-410663d7fb81)| 자신의 id 값으로 관심 등록을 했을 경우 |

### 논의 사항 (선택)
- 자기 자신을 요청하는 예외에 대한 예외처리 파일(`SelfRequestNotAllowedException`)을 추가했습니다.
- 예외처리 방법에 대해 다른 의견이 있으시면 말씀해주세요!

closed #261