### PR TITLE
refactor(coach) : 코치 상세 정보 조회 리팩토링

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDetailDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDetailDto.java
@@ -35,6 +35,7 @@ public record CoachDetailDto(
 	List<ReviewDto> reviews,
 	@NotNull
 	boolean isOpen,
+	boolean isContacted,
 	int countOfReviews,
 	double reviewRating,
 	boolean isLiked,

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -160,19 +160,19 @@ public class CoachService {
 	}
 
 	@Transactional(readOnly = true)
-	public Coach getCoachByUserId(User user) {
-		return coachRepository.findByUser_UserId(user.getUserId())
-			.orElseThrow(AccessDeniedException::new);
-	}
-
-	@Transactional(readOnly = true)
 	public CoachDetailDto getCoachDetail(User user, Long coachId) {
-		Coach coach = (coachId != null) ? getCoachById(coachId) : getCoachByUserId(user);
+		Coach coach = (coachId != null) ? getCoachById(coachId) : getCoachByUserId(user.getUserId());
 
+		if (!user.equals(coach.getUser()) && !coach.getIsOpen()) {
+			throw new AccessDeniedException();
+		}
+		
 		List<ReviewDto> reviews = getReviews(coach);
 		double averageRating = calculateAverageRating(reviews);
 
 		boolean isLiked = isLikedByUser(user, coach);
+		boolean isContacted = matchingRepository.existsByUserUserIdAndCoachCoachId(user.getUserId(), coachId);
+
 		int countOfLikes = getCountOfLikes(coach);
 
 		List<CoachingSportDto> coachingSports = getCoachingSports(coach);
@@ -192,6 +192,7 @@ public class CoachService {
 			.chattingUrl(coach.getChattingUrl())
 			.reviews(reviews)
 			.isOpen(coach.getIsOpen())
+			.isContacted(isContacted)
 			.countOfReviews(reviews.size())
 			.reviewRating(averageRating)
 			.isLiked(isLiked)

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -163,10 +163,12 @@ public class CoachService {
 	public CoachDetailDto getCoachDetail(User user, Long coachId) {
 		Coach coach = (coachId != null) ? getCoachById(coachId) : getCoachByUserId(user.getUserId());
 
-		if (!user.equals(coach.getUser()) && !coach.getIsOpen()) {
+		boolean isSelf = user.getUserId().equals(coach.getUser().getUserId());
+
+		if (!isSelf && !coach.getIsOpen()) {
 			throw new AccessDeniedException();
 		}
-		
+
 		List<ReviewDto> reviews = getReviews(coach);
 		double averageRating = calculateAverageRating(reviews);
 


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- isContact 로직 추가
  - getCoachDetail 메서드에서 `isContacted`값을 계산하는 로직이 추가되었습니다.
  - 이를 통해 사용자가 해당 코치와 이미 매칭된 상태인지 여부를 클라이언트에 전달할 수 있습니다.
- CoachDetailDto 변경
  - CoachDetailDto에 `isContacted`필드가 추가되어, 해당 정보가 응답에 포함되도록 변경되었습니다.
- 본인 여부 확인
  - getCoachDetail 메서드에서 `coachId`가 null인 경우 본인의 코치 정보를 조회하도록 수정했습니다.
  - 본인일 경우 `isOpen` 값이 `false`여도 조회가 가능하도록 예외 처리 로직을 변경했습니다.
- isOpen 검사 조건 추가
  - 본인이 아닌 경우에만` isOpen` 값이 `false`일 때 예외를 발생시키도록 수정하여, 비공개 프로필의 접근을 제한했습니다.
 
### PR Point
- 각 상황에 맞는 예외처리가 되었는지 확인해주세요.

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/020b1f3c-6f7f-4213-ac9a-db32bab6efd6)| 코치 상세 보기 조회 시 `isContacted` 값 추가|
|![image](https://github.com/user-attachments/assets/191d3aa4-5309-481a-ab23-d638196590f3)| `isOpen` = `false`인 코치 조회 시 |
|![image](https://github.com/user-attachments/assets/bcfba821-9a80-4c32-b0cf-79a7082575eb) |  `isOpen` = `false` 여도 코치 본인 `coachId`로 검색 시에는 조회 가능 |


closed #264 
