### PR TITLE
refactor(coach) : 코치 전체 리스트 조회 리팩토링

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/sport/repository/SportRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/sport/repository/SportRepository.java
@@ -1,11 +1,16 @@
 package site.coach_coach.coach_coach_server.sport.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import site.coach_coach.coach_coach_server.sport.domain.Sport;
 
 public interface SportRepository extends JpaRepository<Sport, Long> {
 	Optional<Sport> findBySportName(String sportName);
+
+	@Query("SELECT s.sportId FROM Sport s")
+	List<Long> findAllSportIds();
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 코치 조회 필터링
  - `isOpen` 값이 `false`인 코치는 조회에서 제외되도록 필터링하였습니다.
- 동적 데이터 조회
  - 하드코딩된 sportId 값을 제거하고, 데이터베이스에서 동적으로 조회하여 코드의 유연성을 높였습니다.
  - SportRepository에 findAllSportIds 메서드를 추가하여, JPQL 쿼리를 사용해 모든 sportId를 조회하도록 수정했습니다.

### PR Point
- isOpen 값 검증 로직이 모든 관련 API 및 서비스에 적용되었는지 확인합니다.
- 데이터베이스 스키마와 쿼리가 일치하는지 검토합니다.

closed #266