### PR TITLE
refactor : V16(coachId cascade) & 매칭 삭제/거절에 대한 알림 추가

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -152,7 +152,13 @@ public class CoachService {
 		Matching matching = matchingRepository.findByUser_UserIdAndCoach_CoachId(user.getUserId(), coach.getCoachId())
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CONTACT));
 
+		boolean isMatching = matching.getIsMatching();
 		matchingRepository.delete(matching);
+		if (isMatching) {
+			notificationService.createNotification(userId, coach.getCoachId(), RelationFunctionEnum.delete);
+		} else {
+			notificationService.createNotification(userId, coach.getCoachId(), RelationFunctionEnum.refusal);
+		}
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -155,7 +155,7 @@ public class CoachService {
 		boolean isMatching = matching.getIsMatching();
 		matchingRepository.delete(matching);
 		if (isMatching) {
-			notificationService.createNotification(userId, coach.getCoachId(), RelationFunctionEnum.delete);
+			notificationService.createNotification(userId, coach.getCoachId(), RelationFunctionEnum.cancel);
 		} else {
 			notificationService.createNotification(userId, coach.getCoachId(), RelationFunctionEnum.refusal);
 		}

--- a/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
@@ -1,5 +1,5 @@
 package site.coach_coach.coach_coach_server.common.domain;
 
 public enum RelationFunctionEnum {
-	review, ask, like, match
+	review, ask, like, match, refusal
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
@@ -1,5 +1,5 @@
 package site.coach_coach.coach_coach_server.common.domain;
 
 public enum RelationFunctionEnum {
-	review, ask, like, match, refusal, delete
+	review, ask, like, match, refusal, cancel
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/common/domain/RelationFunctionEnum.java
@@ -1,5 +1,5 @@
 package site.coach_coach.coach_coach_server.common.domain;
 
 public enum RelationFunctionEnum {
-	review, ask, like, match, refusal
+	review, ask, like, match, refusal, delete
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
@@ -9,7 +9,7 @@ public enum NotificationMessage {
 	LIKE_MESSAGE("회원님을 관심 코치로 등록하였습니다."),
 	MATCH_MESSAGE("회원님의 매칭 신청을 수락하셨습니다."),
 	REFUSAL_MESSAGE("매칭 신청을 거절하였습니다."),
-	CANCEL_MESSAGE("회원님을 매칭 취소하였습니다."),
+	CANCEL_MESSAGE("매칭을 취소하였습니다."),
 	USER_MESSAGE("님이 ");
 
 	private final String message;

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
@@ -8,6 +8,7 @@ public enum NotificationMessage {
 	ASK_MESSAGE("매칭을 신청하였습니다."),
 	LIKE_MESSAGE("회원님을 관심 코치로 등록하였습니다."),
 	MATCH_MESSAGE("회원님의 매칭 신청을 수락하셨습니다."),
+	REFUSAL_MESSAGE(" 매칭 신청을 거절하였습니다."),
 	USER_MESSAGE("님이 ");
 
 	private final String message;

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
@@ -8,7 +8,8 @@ public enum NotificationMessage {
 	ASK_MESSAGE("매칭을 신청하였습니다."),
 	LIKE_MESSAGE("회원님을 관심 코치로 등록하였습니다."),
 	MATCH_MESSAGE("회원님의 매칭 신청을 수락하셨습니다."),
-	REFUSAL_MESSAGE(" 매칭 신청을 거절하였습니다."),
+	REFUSAL_MESSAGE("매칭 신청을 거절하였습니다."),
+	DELETE_MESSAGE("회원님을 매칭 취소하였습니다."),
 	USER_MESSAGE("님이 ");
 
 	private final String message;

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/constants/NotificationMessage.java
@@ -9,7 +9,7 @@ public enum NotificationMessage {
 	LIKE_MESSAGE("회원님을 관심 코치로 등록하였습니다."),
 	MATCH_MESSAGE("회원님의 매칭 신청을 수락하셨습니다."),
 	REFUSAL_MESSAGE("매칭 신청을 거절하였습니다."),
-	DELETE_MESSAGE("회원님을 매칭 취소하였습니다."),
+	CANCEL_MESSAGE("회원님을 매칭 취소하였습니다."),
 	USER_MESSAGE("님이 ");
 
 	private final String message;

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -55,7 +55,8 @@ public class NotificationService {
 
 		User receiver;
 
-		if (relationFunction == RelationFunctionEnum.match || relationFunction == RelationFunctionEnum.refusal) {
+		if (relationFunction == RelationFunctionEnum.match || relationFunction == RelationFunctionEnum.refusal
+			|| relationFunction == RelationFunctionEnum.delete) {
 			receiver = user;
 		} else {
 			receiver = coach;
@@ -98,6 +99,8 @@ public class NotificationService {
 				+ NotificationMessage.MATCH_MESSAGE.getMessage();
 			case refusal -> coach.getNickname() + NotificationMessage.USER_MESSAGE.getMessage()
 				+ NotificationMessage.REFUSAL_MESSAGE.getMessage();
+			case delete -> coach.getNickname() + NotificationMessage.USER_MESSAGE.getMessage()
+				+ NotificationMessage.DELETE_MESSAGE.getMessage();
 		};
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -99,8 +99,8 @@ public class NotificationService {
 				+ NotificationMessage.MATCH_MESSAGE.getMessage();
 			case refusal -> coach.getNickname() + NotificationMessage.USER_MESSAGE.getMessage()
 				+ NotificationMessage.REFUSAL_MESSAGE.getMessage();
-			case delete -> coach.getNickname() + NotificationMessage.USER_MESSAGE.getMessage()
-				+ NotificationMessage.DELETE_MESSAGE.getMessage();
+			case cancel -> coach.getNickname() + NotificationMessage.USER_MESSAGE.getMessage()
+				+ NotificationMessage.CANCEL_MESSAGE.getMessage();
 		};
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -53,7 +53,13 @@ public class NotificationService {
 			throw new InvalidInputException(ErrorMessage.INVALID_REQUEST);
 		}
 
-		User receiver = (relationFunction == RelationFunctionEnum.match) ? user : coach;
+		User receiver;
+
+		if (relationFunction == RelationFunctionEnum.match || relationFunction == RelationFunctionEnum.refusal) {
+			receiver = user;
+		} else {
+			receiver = coach;
+		}
 
 		Notification notification = Notification.builder()
 			.user(receiver)
@@ -90,6 +96,8 @@ public class NotificationService {
 			case review -> NotificationMessage.REVIEW_MESSAGE.getMessage();
 			case match -> coach.getNickname() + NotificationMessage.USER_MESSAGE.getMessage()
 				+ NotificationMessage.MATCH_MESSAGE.getMessage();
+			case refusal -> coach.getNickname() + NotificationMessage.USER_MESSAGE.getMessage()
+				+ NotificationMessage.REFUSAL_MESSAGE.getMessage();
 		};
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/notification/service/NotificationService.java
@@ -56,7 +56,7 @@ public class NotificationService {
 		User receiver;
 
 		if (relationFunction == RelationFunctionEnum.match || relationFunction == RelationFunctionEnum.refusal
-			|| relationFunction == RelationFunctionEnum.delete) {
+			|| relationFunction == RelationFunctionEnum.cancel) {
 			receiver = user;
 		} else {
 			receiver = coach;

--- a/src/main/resources/db/migration/V16__add_coach_id_cascade.sql
+++ b/src/main/resources/db/migration/V16__add_coach_id_cascade.sql
@@ -1,3 +1,29 @@
+ALTER TABLE `coachcoach`.`routine_categories`
+DROP FOREIGN KEY `fk_routine_categories_routine_id`;
+ALTER TABLE `coachcoach`.`routine_categories`
+    CHANGE COLUMN `routine_id` `routine_id` BIGINT NULL ;
+ALTER TABLE `coachcoach`.`routine_categories`
+    ADD CONSTRAINT `fk_routine_categories_routine_id`
+        FOREIGN KEY (`routine_id`)
+            REFERENCES `coachcoach`.`routines` (`routine_id`)
+            ON DELETE SET NULL;
+
+ALTER TABLE `coachcoach`.`completed_categories`
+DROP FOREIGN KEY `fk_completed_categories_routine_category_id`;
+ALTER TABLE `coachcoach`.`completed_categories`
+    ADD CONSTRAINT `fk_completed_categories_routine_category_id`
+        FOREIGN KEY (`routine_category_id`)
+            REFERENCES `coachcoach`.`routine_categories` (`routine_category_id`)
+            ON DELETE RESTRICT;
+
+ALTER TABLE `coachcoach`.`routines`
+DROP FOREIGN KEY `fk_routines_coach_id`;
+ALTER TABLE `coachcoach`.`routines`
+    ADD CONSTRAINT `fk_routines_coach_id`
+        FOREIGN KEY (`coach_id`)
+            REFERENCES `coachcoach`.`coaches` (`coach_id`)
+            ON DELETE SET NULL;
+
 ALTER TABLE `coachcoach`.`reviews`
 DROP FOREIGN KEY `fk_reviews_coach_id`;
 ALTER TABLE `coachcoach`.`reviews`
@@ -29,3 +55,5 @@ ALTER TABLE `coachcoach`.`user_coach_matching`
         FOREIGN KEY (`coach_id`)
             REFERENCES `coachcoach`.`coaches` (`coach_id`)
             ON DELETE CASCADE;
+
+

--- a/src/main/resources/db/migration/V16__add_coach_id_cascade.sql
+++ b/src/main/resources/db/migration/V16__add_coach_id_cascade.sql
@@ -1,0 +1,31 @@
+ALTER TABLE `coachcoach`.`reviews`
+DROP FOREIGN KEY `fk_reviews_coach_id`;
+ALTER TABLE `coachcoach`.`reviews`
+    ADD CONSTRAINT `fk_reviews_coach_id`
+        FOREIGN KEY (`coach_id`)
+            REFERENCES `coachcoach`.`coaches` (`coach_id`)
+            ON DELETE CASCADE;
+
+ALTER TABLE `coachcoach`.`routines`
+DROP FOREIGN KEY `fk_routines_coach_id`;
+ALTER TABLE `coachcoach`.`routines`
+    ADD CONSTRAINT `fk_routines_coach_id`
+        FOREIGN KEY (`coach_id`)
+            REFERENCES `coachcoach`.`coaches` (`coach_id`)
+            ON DELETE CASCADE;
+
+ALTER TABLE `coachcoach`.`user_coach_likes`
+DROP FOREIGN KEY `fk_user_coach_likes_coach_id`;
+ALTER TABLE `coachcoach`.`user_coach_likes`
+    ADD CONSTRAINT `fk_user_coach_likes_coach_id`
+        FOREIGN KEY (`coach_id`)
+            REFERENCES `coachcoach`.`coaches` (`coach_id`)
+            ON DELETE CASCADE;
+
+ALTER TABLE `coachcoach`.`user_coach_matching`
+DROP FOREIGN KEY `fk_user_coach_matching_coach_id`;
+ALTER TABLE `coachcoach`.`user_coach_matching`
+    ADD CONSTRAINT `fk_user_coach_matching_coach_id`
+        FOREIGN KEY (`coach_id`)
+            REFERENCES `coachcoach`.`coaches` (`coach_id`)
+            ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V16__add_coach_id_cascade.sql
+++ b/src/main/resources/db/migration/V16__add_coach_id_cascade.sql
@@ -1,7 +1,7 @@
 ALTER TABLE `coachcoach`.`routine_categories`
-DROP FOREIGN KEY `fk_routine_categories_routine_id`;
+    DROP FOREIGN KEY `fk_routine_categories_routine_id`;
 ALTER TABLE `coachcoach`.`routine_categories`
-    CHANGE COLUMN `routine_id` `routine_id` BIGINT NULL ;
+    CHANGE COLUMN `routine_id` `routine_id` BIGINT NULL;
 ALTER TABLE `coachcoach`.`routine_categories`
     ADD CONSTRAINT `fk_routine_categories_routine_id`
         FOREIGN KEY (`routine_id`)
@@ -9,7 +9,7 @@ ALTER TABLE `coachcoach`.`routine_categories`
             ON DELETE SET NULL;
 
 ALTER TABLE `coachcoach`.`completed_categories`
-DROP FOREIGN KEY `fk_completed_categories_routine_category_id`;
+    DROP FOREIGN KEY `fk_completed_categories_routine_category_id`;
 ALTER TABLE `coachcoach`.`completed_categories`
     ADD CONSTRAINT `fk_completed_categories_routine_category_id`
         FOREIGN KEY (`routine_category_id`)
@@ -17,7 +17,7 @@ ALTER TABLE `coachcoach`.`completed_categories`
             ON DELETE RESTRICT;
 
 ALTER TABLE `coachcoach`.`routines`
-DROP FOREIGN KEY `fk_routines_coach_id`;
+    DROP FOREIGN KEY `fk_routines_coach_id`;
 ALTER TABLE `coachcoach`.`routines`
     ADD CONSTRAINT `fk_routines_coach_id`
         FOREIGN KEY (`coach_id`)
@@ -25,23 +25,15 @@ ALTER TABLE `coachcoach`.`routines`
             ON DELETE SET NULL;
 
 ALTER TABLE `coachcoach`.`reviews`
-DROP FOREIGN KEY `fk_reviews_coach_id`;
+    DROP FOREIGN KEY `fk_reviews_coach_id`;
 ALTER TABLE `coachcoach`.`reviews`
     ADD CONSTRAINT `fk_reviews_coach_id`
         FOREIGN KEY (`coach_id`)
             REFERENCES `coachcoach`.`coaches` (`coach_id`)
             ON DELETE CASCADE;
 
-ALTER TABLE `coachcoach`.`routines`
-DROP FOREIGN KEY `fk_routines_coach_id`;
-ALTER TABLE `coachcoach`.`routines`
-    ADD CONSTRAINT `fk_routines_coach_id`
-        FOREIGN KEY (`coach_id`)
-            REFERENCES `coachcoach`.`coaches` (`coach_id`)
-            ON DELETE CASCADE;
-
 ALTER TABLE `coachcoach`.`user_coach_likes`
-DROP FOREIGN KEY `fk_user_coach_likes_coach_id`;
+    DROP FOREIGN KEY `fk_user_coach_likes_coach_id`;
 ALTER TABLE `coachcoach`.`user_coach_likes`
     ADD CONSTRAINT `fk_user_coach_likes_coach_id`
         FOREIGN KEY (`coach_id`)
@@ -49,11 +41,12 @@ ALTER TABLE `coachcoach`.`user_coach_likes`
             ON DELETE CASCADE;
 
 ALTER TABLE `coachcoach`.`user_coach_matching`
-DROP FOREIGN KEY `fk_user_coach_matching_coach_id`;
+    DROP FOREIGN KEY `fk_user_coach_matching_coach_id`;
 ALTER TABLE `coachcoach`.`user_coach_matching`
     ADD CONSTRAINT `fk_user_coach_matching_coach_id`
         FOREIGN KEY (`coach_id`)
             REFERENCES `coachcoach`.`coaches` (`coach_id`)
             ON DELETE CASCADE;
 
-
+ALTER TABLE `coachcoach`.`notifications`
+    MODIFY COLUMN `relation_function` ENUM ('ask', 'like', 'review', 'match', 'refusal', 'cancel') NOT NULL;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 코치 id에 대해서 cascade를 처리하였습니다. 
- 빠진 내용이 있는지 확인해주세요
- 매칭 취소/거절에 대한 알림을 추가하였습니다.
  - 스크린샷에서 `XXX님이 회원님을 매칭 취소하였습니다.` -> `XXX님이 매칭을 취소하였습니다.` 로 수정하였습니다.

![image](https://github.com/user-attachments/assets/91d64309-4b3c-4d75-aeb8-40648dc618c0)


### 논의 사항 (선택)
- `completed_categories`에 대한 기획상 의논이 필요할 것 같습니다.
  - 현재 `routines_category`의 id에 대하여 cascade 설정을 하고 있는데요. 루틴이나 카테고리를 삭제하더라도 이미 완료한 카테고리에 대해서는 기록에는 남아있는 것이 좋겠다고 생각하여 cascade 설정을 하지 않기로 하지 않았었나요????
  - 근데 사실 cascade 설정을 하지 않으면 로직 상 문제가 생길 것 같긴 합니다.. routine_category_id가 null이므로 그에 대한 정보를 기록 디테일 페이지에서 가져올 수가 없게 되니까요
- 코치가 탈퇴한다고 해서 routines 를 삭제하는 것도 필수인지가 궁금합니다
  - 탈퇴해서 더 이상 추가를 못한다고 할 지언정... 코치가 이전에 짜주었던 내용을 회원이 궁금해할 수도 있으니까요 남기는 것도 나쁘지는 않을 것 같아서요
  - 하지만 이렇게 될 경우 coachId가 null이 되므로 user 자신의 routine인지 탈퇴한 coach가 짠 루틴인지 구분할 수 없다는 .. 단점이 있을 것 같긴합니다..(아닐수도있음..)

closed #299 
