### PR TITLE
refactor(category) : 루틴이 삭제되더라도 완료한 카테고리 기록 미삭제 

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/action/repository/ActionRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/repository/ActionRepository.java
@@ -1,8 +1,11 @@
 package site.coach_coach.coach_coach_server.action.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import site.coach_coach.coach_coach_server.action.domain.Action;
 
 public interface ActionRepository extends JpaRepository<Action, Long> {
+	Optional<Action> findByActionIdAndCategory_Routine_RoutineIdIsNotNull(Long actionId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -1,7 +1,5 @@
 package site.coach_coach.coach_coach_server.action.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,11 +24,8 @@ public class ActionService {
 	@Transactional
 	public Long createAction(Long categoryId, Long userIdByJwt,
 		CreateActionRequest createActionRequest) {
-		Category category = categoryRepository.findById(categoryId)
+		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
-
-		Optional.ofNullable(category.getRoutine())
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 
@@ -40,11 +35,8 @@ public class ActionService {
 
 	@Transactional
 	public void deleteAction(Long actionId, Long userIdByJwt) {
-		Action action = actionRepository.findById(actionId)
+		Action action = actionRepository.findByActionIdAndCategory_Routine_RoutineIdIsNotNull(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
-
-		Optional.ofNullable(action.getCategory().getRoutine())
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);
 
@@ -53,11 +45,8 @@ public class ActionService {
 
 	@Transactional
 	public void updateActionInfo(UpdateActionInfoRequest updateActionInfoRequest, Long actionId, Long userIdByJwt) {
-		Action action = actionRepository.findById(actionId)
+		Action action = actionRepository.findByActionIdAndCategory_Routine_RoutineIdIsNotNull(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
-
-		Optional.ofNullable(action.getCategory().getRoutine())
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);
 		action.updateActionInfo(updateActionInfoRequest);

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -1,5 +1,7 @@
 package site.coach_coach.coach_coach_server.action.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,9 @@ public class ActionService {
 		Category category = categoryRepository.findById(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
+		Optional.ofNullable(category.getRoutine())
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
+
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 
 		Action action = Action.of(createActionRequest, category);
@@ -38,6 +43,9 @@ public class ActionService {
 		Action action = actionRepository.findById(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
 
+		Optional.ofNullable(action.getCategory().getRoutine())
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
+
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);
 
 		actionRepository.deleteById(actionId);
@@ -47,6 +55,9 @@ public class ActionService {
 	public void updateActionInfo(UpdateActionInfoRequest updateActionInfoRequest, Long actionId, Long userIdByJwt) {
 		Action action = actionRepository.findById(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
+
+		Optional.ofNullable(action.getCategory().getRoutine())
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);
 		action.updateActionInfo(updateActionInfoRequest);

--- a/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
@@ -44,7 +44,6 @@ public class Category extends DateEntity {
 	@Column(name = "category_name")
 	private String categoryName;
 
-	@NotNull
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "routine_id")
 	private Routine routine;

--- a/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import site.coach_coach.coach_coach_server.category.domain.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-	Optional<Category> findByCategoryIdAndRoutine_RoutineId(Long categoryId, Long routineId);
+	Optional<Category> findByCategoryIdAndRoutine_RoutineIdIsNotNull(Long categoryId);
 
 	@Modifying
 	@Query("UPDATE Category c SET c.isCompleted = FALSE")

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -1,7 +1,5 @@
 package site.coach_coach.coach_coach_server.category.service;
 
-import java.util.Optional;
-
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,11 +38,8 @@ public class CategoryService {
 	@Transactional
 	public void deleteCategory(Long categoryId, Long userIdByJwt) {
 
-		Category category = categoryRepository.findById(categoryId)
+		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
-
-		Optional.ofNullable(category.getRoutine())
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 
@@ -54,11 +49,9 @@ public class CategoryService {
 
 	@Transactional
 	public void updateCategory(UpdateCategoryInfoRequest updateCategoryInfoRequest, Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.findById(categoryId)
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
-		Optional.ofNullable(category.getRoutine())
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
+		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -37,7 +37,6 @@ public class CategoryService {
 
 	@Transactional
 	public void deleteCategory(Long categoryId, Long userIdByJwt) {
-
 		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
@@ -49,7 +48,6 @@ public class CategoryService {
 
 	@Transactional
 	public void updateCategory(UpdateCategoryInfoRequest updateCategoryInfoRequest, Long categoryId, Long userIdByJwt) {
-
 		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -1,5 +1,7 @@
 package site.coach_coach.coach_coach_server.category.service;
 
+import java.util.Optional;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +43,9 @@ public class CategoryService {
 		Category category = categoryRepository.findById(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
+		Optional.ofNullable(category.getRoutine())
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
+
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 
 		categoryRepository.deleteById(categoryId);
@@ -51,6 +56,9 @@ public class CategoryService {
 	public void updateCategory(UpdateCategoryInfoRequest updateCategoryInfoRequest, Long categoryId, Long userIdByJwt) {
 		Category category = categoryRepository.findById(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
+
+		Optional.ofNullable(category.getRoutine())
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 

--- a/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
@@ -1,7 +1,5 @@
 package site.coach_coach.coach_coach_server.completedcategory.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,11 +23,8 @@ public class CompletedCategoryService {
 	private final CategoryRepository categoryRepository;
 
 	private Category validateAccessToCategory(Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.findById(categoryId)
+		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
-
-		Optional.ofNullable(category.getRoutine())
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		if (!category.getRoutine().getUser().getUserId().equals(userIdByJwt)) {
 			throw new AccessDeniedException();

--- a/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
@@ -1,5 +1,7 @@
 package site.coach_coach.coach_coach_server.completedcategory.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,9 @@ public class CompletedCategoryService {
 	private Category validateAccessToCategory(Long categoryId, Long userIdByJwt) {
 		Category category = categoryRepository.findById(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
+
+		Optional.ofNullable(category.getRoutine())
+			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ROUTINE));
 
 		if (!category.getRoutine().getUser().getUserId().equals(userIdByJwt)) {
 			throw new AccessDeniedException();

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/dto/RecordsDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/dto/RecordsDto.java
@@ -1,6 +1,7 @@
 package site.coach_coach.coach_coach_server.userrecord.dto;
 
 import java.util.List;
+import java.util.Optional;
 
 import site.coach_coach.coach_coach_server.coach.domain.Coach;
 import site.coach_coach.coach_coach_server.completedcategory.dto.CompletedCategoryDto;
@@ -13,12 +14,13 @@ public record RecordsDto(
 	String routineName,
 	List<CompletedCategoryDto> completedCategories
 ) {
-	public static RecordsDto from(Routine routine, Coach coach, List<CompletedCategoryDto> completedCategories) {
+	public static RecordsDto from(Optional<Routine> routine, Coach coach,
+		List<CompletedCategoryDto> completedCategories) {
 		return new RecordsDto(
 			coach != null ? coach.getCoachId() : null,
 			coach != null ? coach.getUser().getNickname() : null,
 			coach != null ? coach.getUser().getProfileImageUrl() : null,
-			routine.getRoutineName(),
+			routine.map(Routine::getRoutineName).orElse(null),
 			completedCategories
 		);
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -181,9 +182,9 @@ public class UserRecordService {
 	}
 
 	private List<RecordsDto> mapToRecordsDto(List<CompletedCategory> completedCategories) {
-		Map<Routine, List<CompletedCategoryDto>> routineToCategoriesMap = completedCategories.stream()
+		Map<Optional<Routine>, List<CompletedCategoryDto>> routineToCategoriesMap = completedCategories.stream()
 			.collect(Collectors.groupingBy(
-				c -> c.getCategory().getRoutine(),
+				c -> Optional.ofNullable(c.getCategory().getRoutine()),
 				Collectors.mapping(
 					CompletedCategoryDto::from,
 					Collectors.toList()
@@ -192,10 +193,16 @@ public class UserRecordService {
 
 		return routineToCategoriesMap.entrySet().stream()
 			.map(entry -> {
-				Routine routine = entry.getKey();
+				Optional<Routine> routine = entry.getKey();
 				List<CompletedCategoryDto> completedCategoryDtos = entry.getValue();
-				Coach coach = routine.getCoach();
+
+				if (routine.isEmpty()) {
+					return RecordsDto.from(routine, null, completedCategoryDtos);
+				}
+
+				Coach coach = routine.get().getCoach();
 				return RecordsDto.from(routine, coach, completedCategoryDtos);
+
 			})
 			.collect(Collectors.toList());
 	}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 루틴 삭제 시, 하위 카테고리와 운동은 미삭제하도록 결정
  - 삭제된 루틴에 대한 조회 시, 루틴 상태에 따른 예외처리 진행
  - 카테고리 수정/삭제, 카테고리 수행 완료/미완료, 운동 추가/삭제/수정 시 임의이 URL 입력에 대한 예외처리
- 기록 페이지 조회 시, 삭제된 루틴 하위의 완료된 카테고리의 경우 `routineName`을 `null`로 응답 

### PR Point
확인한 예외 이외에 다른 부분에서 예외가 발생할 수 있는지 확인 부탁드려요!

### 📸 스크린샷
|사진|설명|
|---|---|
|<img width="686" alt="image" src="https://github.com/user-attachments/assets/64fe4d78-2b44-4a92-9f2c-e4c65a666476">|완료한 카테고리가 속한 루틴이 삭제되었을 때, 기록 페이지 조회시 반환값|

closed #304
