### PR TITLE
refactor : 카테고리 완료 상태 초기화 로직 리팩토링

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
@@ -12,6 +12,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 	Optional<Category> findByCategoryIdAndRoutine_RoutineId(Long categoryId, Long routineId);
 
 	@Modifying
-	@Query("UPDATE Category c SET c.isCompleted = FALSE")
+	@Query("UPDATE Category c SET c.isCompleted = FALSE WHERE c.routine.routineId IS NOT NULL")
 	void resetIsCompleted();
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 루틴 삭제 시, 카테고리는 삭제하지 않는 상황에서 카테고리 완료 상태 초기화 시에 루틴이 삭제된
   카테고리의 경우 기록 조회를 위한 데이터로 남아있기에 카테고리의 완료 상태 초기화가 불필요합니다.
   따라서 루틴이 삭제된 카테고리를 제외하고 카테고리 상태를 초기화합니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/cec44fc1-6754-40cc-bcff-0e159b7f0bfa)|삭제된 카테고리와 삭제되지 않은 카테고리의 완료 상황|
|![image](https://github.com/user-attachments/assets/955de4b5-6ecc-4e6c-81c5-cc14728ae255)|루틴이 삭제된 카테고리를 제외한 카테고리의 완료 상태 초기화 성공 |

closed #308
