### PR TITLE
refactor(category) : 카테고리에 isDeleted 추가 및 카테고리 삭제 로직 리팩토링

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/action/repository/ActionRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/repository/ActionRepository.java
@@ -3,9 +3,13 @@ package site.coach_coach.coach_coach_server.action.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import site.coach_coach.coach_coach_server.action.domain.Action;
 
 public interface ActionRepository extends JpaRepository<Action, Long> {
-	Optional<Action> findByActionIdAndCategory_Routine_RoutineIdIsNotNull(Long actionId);
+	@Query("SELECT a FROM Action a WHERE a.actionId = :actionId AND a.category.isDeleted IS FALSE "
+		+ "AND a.category.routine.routineId IS NOT NULL")
+	Optional<Action> checkIsExistAction(@Param("actionId") Long actionId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/repository/ActionRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/repository/ActionRepository.java
@@ -11,5 +11,5 @@ import site.coach_coach.coach_coach_server.action.domain.Action;
 public interface ActionRepository extends JpaRepository<Action, Long> {
 	@Query("SELECT a FROM Action a WHERE a.actionId = :actionId AND a.category.isDeleted IS FALSE "
 		+ "AND a.category.routine.routineId IS NOT NULL")
-	Optional<Action> checkIsExistAction(@Param("actionId") Long actionId);
+	Optional<Action> findExistAction(@Param("actionId") Long actionId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -24,7 +24,7 @@ public class ActionService {
 	@Transactional
 	public Long createAction(Long categoryId, Long userIdByJwt,
 		CreateActionRequest createActionRequest) {
-		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
+		Category category = categoryRepository.checkIsExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
@@ -35,7 +35,7 @@ public class ActionService {
 
 	@Transactional
 	public void deleteAction(Long actionId, Long userIdByJwt) {
-		Action action = actionRepository.findByActionIdAndCategory_Routine_RoutineIdIsNotNull(actionId)
+		Action action = actionRepository.checkIsExistAction(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
 
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);
@@ -45,7 +45,7 @@ public class ActionService {
 
 	@Transactional
 	public void updateActionInfo(UpdateActionInfoRequest updateActionInfoRequest, Long actionId, Long userIdByJwt) {
-		Action action = actionRepository.findByActionIdAndCategory_Routine_RoutineIdIsNotNull(actionId)
+		Action action = actionRepository.checkIsExistAction(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
 
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);

--- a/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/action/service/ActionService.java
@@ -24,7 +24,7 @@ public class ActionService {
 	@Transactional
 	public Long createAction(Long categoryId, Long userIdByJwt,
 		CreateActionRequest createActionRequest) {
-		Category category = categoryRepository.checkIsExistCategory(categoryId)
+		Category category = categoryRepository.findExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
@@ -35,7 +35,7 @@ public class ActionService {
 
 	@Transactional
 	public void deleteAction(Long actionId, Long userIdByJwt) {
-		Action action = actionRepository.checkIsExistAction(actionId)
+		Action action = actionRepository.findExistAction(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
 
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);
@@ -45,7 +45,7 @@ public class ActionService {
 
 	@Transactional
 	public void updateActionInfo(UpdateActionInfoRequest updateActionInfoRequest, Long actionId, Long userIdByJwt) {
-		Action action = actionRepository.checkIsExistAction(actionId)
+		Action action = actionRepository.findExistAction(actionId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_ACTION));
 
 		routineService.validateIsMyRoutine(action.getCategory().getRoutine().getRoutineId(), userIdByJwt);

--- a/src/main/java/site/coach_coach/coach_coach_server/category/controller/CategoryController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/controller/CategoryController.java
@@ -18,8 +18,6 @@ import site.coach_coach.coach_coach_server.category.dto.CreateCategoryRequest;
 import site.coach_coach.coach_coach_server.category.dto.CreateCategoryResponse;
 import site.coach_coach.coach_coach_server.category.dto.UpdateCategoryInfoRequest;
 import site.coach_coach.coach_coach_server.category.service.CategoryService;
-import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
-import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,18 +38,17 @@ public class CategoryController {
 	}
 
 	@DeleteMapping("/v1/categories/{categoryId}")
-	public ResponseEntity<SuccessResponse> deleteCategory(
+	public ResponseEntity<Void> deleteCategory(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable(name = "categoryId") Long categoryId
 	) {
 		Long userIdByJwt = userDetails.getUserId();
 		categoryService.deleteCategory(categoryId, userIdByJwt);
-		return ResponseEntity.ok(
-			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_CATEGORY_SUCCESS.getMessage()));
+		return ResponseEntity.noContent().build();
 	}
 
 	@PatchMapping("/v1/categories/{categoryId}")
-	public ResponseEntity<SuccessResponse> updateCategory(
+	public ResponseEntity<Void> updateCategory(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable(name = "categoryId") Long categoryId,
 		@RequestBody @Valid UpdateCategoryInfoRequest updateCategoryInfoRequest

--- a/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
@@ -52,6 +52,10 @@ public class Category extends DateEntity {
 	@Column(name = "is_completed")
 	private Boolean isCompleted;
 
+	@NotNull
+	@Column(name = "is_deleted")
+	private Boolean isDeleted;
+
 	@OneToMany(mappedBy = "category")
 	private List<Action> actionList;
 
@@ -64,5 +68,9 @@ public class Category extends DateEntity {
 
 	public void changeIsCompleted() {
 		this.isCompleted = !this.isCompleted;
+	}
+
+	public void changeIsDeleted() {
+		this.isDeleted = true;
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/domain/Category.java
@@ -54,7 +54,7 @@ public class Category extends DateEntity {
 
 	@NotNull
 	@Column(name = "is_deleted")
-	private Boolean isDeleted;
+	private boolean isDeleted;
 
 	@OneToMany(mappedBy = "category")
 	private List<Action> actionList;

--- a/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import site.coach_coach.coach_coach_server.category.domain.Category;
 
@@ -14,4 +15,12 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 	@Modifying
 	@Query("UPDATE Category c SET c.isCompleted = FALSE WHERE c.routine.routineId IS NOT NULL")
 	void resetIsCompleted();
+
+	@Modifying
+	@Query("UPDATE Category c SET c.isDeleted = TRUE WHERE c.routine.routineId = :routineId")
+	void changeIsDeletedByRemoveRoutine(@Param("routineId") Long routineId);
+
+	@Query("SELECT c FROM Category c WHERE c.categoryId = :categoryId AND c.isDeleted IS FALSE "
+		+ "AND c.routine.routineId IS NOT NULL")
+	Optional<Category> checkIsExistCategory(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/repository/CategoryRepository.java
@@ -22,5 +22,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 	@Query("SELECT c FROM Category c WHERE c.categoryId = :categoryId AND c.isDeleted IS FALSE "
 		+ "AND c.routine.routineId IS NOT NULL")
-	Optional<Category> checkIsExistCategory(@Param("categoryId") Long categoryId);
+	Optional<Category> findExistCategory(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -30,6 +30,7 @@ public class CategoryService {
 			.routine(routine)
 			.categoryName(createCategoryRequest.categoryName())
 			.isCompleted(false)
+			.isDeleted(false)
 			.build();
 
 		return categoryRepository.save(category).getCategoryId();
@@ -37,18 +38,18 @@ public class CategoryService {
 
 	@Transactional
 	public void deleteCategory(Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
+		Category category = categoryRepository.checkIsExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
 
-		categoryRepository.deleteById(categoryId);
+		category.changeIsDeleted();
 
 	}
 
 	@Transactional
 	public void updateCategory(UpdateCategoryInfoRequest updateCategoryInfoRequest, Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
+		Category category = categoryRepository.checkIsExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);

--- a/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/category/service/CategoryService.java
@@ -38,7 +38,7 @@ public class CategoryService {
 
 	@Transactional
 	public void deleteCategory(Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.checkIsExistCategory(categoryId)
+		Category category = categoryRepository.findExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);
@@ -49,7 +49,7 @@ public class CategoryService {
 
 	@Transactional
 	public void updateCategory(UpdateCategoryInfoRequest updateCategoryInfoRequest, Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.checkIsExistCategory(categoryId)
+		Category category = categoryRepository.findExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		routineService.validateIsMyRoutine(category.getRoutine().getRoutineId(), userIdByJwt);

--- a/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
@@ -23,7 +23,7 @@ public class CompletedCategoryService {
 	private final CategoryRepository categoryRepository;
 
 	private Category validateAccessToCategory(Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.findByCategoryIdAndRoutine_RoutineIdIsNotNull(categoryId)
+		Category category = categoryRepository.checkIsExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		if (!category.getRoutine().getUser().getUserId().equals(userIdByJwt)) {

--- a/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/completedcategory/service/CompletedCategoryService.java
@@ -23,7 +23,7 @@ public class CompletedCategoryService {
 	private final CategoryRepository categoryRepository;
 
 	private Category validateAccessToCategory(Long categoryId, Long userIdByJwt) {
-		Category category = categoryRepository.checkIsExistCategory(categoryId)
+		Category category = categoryRepository.findExistCategory(categoryId)
 			.orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND_CATEGORY));
 
 		if (!category.getRoutine().getUser().getUserId().equals(userIdByJwt)) {

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/controller/RoutineController.java
@@ -18,8 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
-import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
-import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
 import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineResponse;
 import site.coach_coach.coach_coach_server.routine.dto.RoutineForListDto;
@@ -74,14 +72,13 @@ public class RoutineController {
 	}
 
 	@DeleteMapping("/v1/routines/{routineId}")
-	public ResponseEntity<SuccessResponse> deleteRoutine(
+	public ResponseEntity<Void> deleteRoutine(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@PathVariable(name = "routineId") Long routineId
 	) {
 		Long userIdByJwt = userDetails.getUserId();
 		routineService.deleteRoutine(routineId, userIdByJwt);
-		return ResponseEntity.ok(
-			new SuccessResponse(HttpStatus.OK.value(), SuccessMessage.DELETE_ROUTINE_SUCCESS.getMessage()));
+		return ResponseEntity.noContent().build();
 	}
 
 	@GetMapping("/v1/routines/{routineId}")

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineResponse.java
@@ -16,7 +16,7 @@ public record RoutineResponse(
 ) {
 	public static RoutineResponse from(Routine routine) {
 		List<CategoryDto> categoryList = routine.getCategoryList().stream()
-			.filter((category -> !category.getIsDeleted()))
+			.filter((category -> !category.isDeleted()))
 			.map(CategoryDto::from)
 			.collect(Collectors.toList());
 

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineResponse.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineResponse.java
@@ -16,6 +16,7 @@ public record RoutineResponse(
 ) {
 	public static RoutineResponse from(Routine routine) {
 		List<CategoryDto> categoryList = routine.getCategoryList().stream()
+			.filter((category -> !category.getIsDeleted()))
 			.map(CategoryDto::from)
 			.collect(Collectors.toList());
 

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/service/RoutineService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.coach_coach.coach_coach_server.category.repository.CategoryRepository;
 import site.coach_coach.coach_coach_server.coach.domain.Coach;
 import site.coach_coach.coach_coach_server.coach.repository.CoachRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
@@ -36,6 +37,7 @@ public class RoutineService {
 	private final CoachRepository coachRepository;
 	private final UserRepository userRepository;
 	private final SportRepository sportRepository;
+	private final CategoryRepository categoryRepository;
 
 	public void checkIsMatching(Long userId, Long coachId) {
 		matchingRepository.findByUser_UserIdAndCoach_CoachId(userId, coachId)
@@ -162,6 +164,7 @@ public class RoutineService {
 	@Transactional
 	public void deleteRoutine(Long routineId, Long userIdByJwt) {
 		validateIsMyRoutine(routineId, userIdByJwt);
+		categoryRepository.changeIsDeletedByRemoveRoutine(routineId);
 		routineRepository.deleteById(routineId);
 	}
 

--- a/src/main/resources/db/migration/V17__add_is_deleted_column.sql
+++ b/src/main/resources/db/migration/V17__add_is_deleted_column.sql
@@ -1,0 +1,2 @@
+alter table `coachcoach`.`routine_categories`
+ADD COLUMN `is_deleted` BIT(1) NOT NULL DEFAULT b'0' AFTER `is_completed`;

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -29,7 +29,6 @@ import site.coach_coach.coach_coach_server.auth.jwt.TokenProvider;
 import site.coach_coach.coach_coach_server.auth.userdetails.CustomUserDetails;
 import site.coach_coach.coach_coach_server.category.dto.CategoryDto;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
-import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
 import site.coach_coach.coach_coach_server.common.exception.AccessDeniedException;
 import site.coach_coach.coach_coach_server.common.exception.NotFoundException;
 import site.coach_coach.coach_coach_server.routine.dto.CreateRoutineRequest;
@@ -209,11 +208,8 @@ public class RoutineControllerTest {
 		doNothing().when(routineService).deleteRoutine(1L, userIdByJwt);
 
 		MvcResult result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/routines/1").with(csrf()))
-			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.status().isNoContent())
 			.andReturn();
-
-		assertThat(result.getResponse().getContentAsString()).contains(
-			SuccessMessage.DELETE_ROUTINE_SUCCESS.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 카테고리 Entity에 is_deleted 데이터 추가
- 루틴 및 카테고리 삭제 시, 실제 삭제가 아닌 is_deleted를 true로 설정
- 완료된 카테고리 삭제 상태로 변경 가능
- 기록 페이지의 완료 카테고리 조회 시
  - 삭제된 카테고리 : routineName 정상 출력
- 루틴 개별 조회 시, 삭제된 카테고리 제외하고 조회  
- is_delete가 true인 카테고리 접근 시 예외 처리
  - 카테고리 수정/삭제
  - 운동 추가
  - 카테고리 완료/완료 취소 시
    -> 접근 category_id의 is_deleted 값 추가 확인 
  - 운동 수정/삭제 시
    -> 접근 action_id의 is_deleted 값 추가 확인 

### PR Point
- `checkIsExistCategory`와 `checkIsExistAction`을 만든 이유는 기존의 JPA 메서드로 사용 시
  `is_deleted`값 비교를 할 때 `~AndIsDeletedIsFalse` 와 같이 JPA 네이밍 파싱 문제가 발생하여 이를 해결하기 위함입니다.

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/a590e142-ead8-45e2-a688-a44ec040d79f)<img width="693" alt="image" src="https://github.com/user-attachments/assets/54d9f387-0287-41d3-a040-2070ea6b8bb1">![image](https://github.com/user-attachments/assets/712a9219-ea61-4c37-a885-991883d04ace)|완료한 카테고리 삭제 가능|
|![image](https://github.com/user-attachments/assets/8e9f0a8b-fc68-435f-808a-08180d99c8c5)|카테고리 삭제 후, 기록페이지에서 조회 가능|

closed #314
