### PR TITLE
refactor(coach) : 코치 리스트 조회 리뷰순 정렬 수정

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -44,7 +44,7 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "WHERE (:sports IS NULL OR cs.sport.sportId IN :sports) "
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
 		+ "GROUP BY c.coachId "
-		+ "ORDER BY COUNT(r.reviewId) DESC")
+		+ "ORDER BY COUNT(r) DESC")
 	Page<Coach> findAllWithReviewsSorted(@Param("sports") List<Long> sports,
 		@Param("search") String search,
 		Pageable pageable);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -44,7 +44,7 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "WHERE (:sports IS NULL OR cs.sport.sportId IN :sports) "
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
 		+ "GROUP BY c.coachId "
-		+ "ORDER BY COUNT(r) DESC")
+		+ "ORDER BY COUNT(r.reviewId) DESC")
 	Page<Coach> findAllWithReviewsSorted(@Param("sports") List<Long> sports,
 		@Param("search") String search,
 		Pageable pageable);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -225,7 +225,7 @@ public class CoachService {
 
 		List<Long> allSportsIds = sportRepository.findAllSportIds();
 
-		Sort sort = Sort.by("updatedAt").descending();
+		Sort sort = Sort.by(Sort.Order.desc("updatedAt"));
 		Pageable pageable = PageRequest.of(page - 1, 20, sort);
 
 		List<Long> sportsList = (sports != null && !sports.isEmpty()) ? parseSports(sports) : allSportsIds;
@@ -245,7 +245,8 @@ public class CoachService {
 			throw new NotFoundException(ErrorMessage.NOT_FOUND_PAGE);
 		}
 
-		List<CoachListDto> coaches = coachesPage.stream()
+		List<CoachListDto> coaches = coachesPage.getContent().stream()
+			.filter(Coach::getIsOpen)
 			.map(coach -> getCoachListDto(coach, user))
 			.collect(Collectors.toList());
 


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 코치 리스트 `리뷰순` 정렬 시 오류 해결
  - 기존 : 리뷰ID로 정렬
  - 현재 : r가 null이 아닌 모든 리뷰를 카운트
- 필터링 후 페이지 처리
  - Page<Coach>를 stream()으로 필터링하여 Coach::getIsOpen 조건을 추가

closed #317
