### PR TITLE
feat : 루틴의 반복일자 기능 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/routine/converter/DayOfWeekSetConverter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/converter/DayOfWeekSetConverter.java
@@ -2,7 +2,6 @@ package site.coach_coach.coach_coach_server.routine.converter;
 
 import java.time.DayOfWeek;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -19,8 +18,7 @@ public class DayOfWeekSetConverter implements AttributeConverter<Set<DayOfWeek>,
 
 	@Override
 	public Set<DayOfWeek> convertToEntityAttribute(String dbData) {
-		return new HashSet<>(Arrays.asList(dbData.split(",")))
-			.stream()
+		return Arrays.stream(dbData.split(","))
 			.map(DayOfWeek::valueOf)
 			.collect(Collectors.toSet());
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/converter/DayOfWeekSetConverter.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/converter/DayOfWeekSetConverter.java
@@ -1,0 +1,27 @@
+package site.coach_coach.coach_coach_server.routine.converter;
+
+import java.time.DayOfWeek;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class DayOfWeekSetConverter implements AttributeConverter<Set<DayOfWeek>, String> {
+
+	@Override
+	public String convertToDatabaseColumn(Set<DayOfWeek> attribute) {
+		return String.join(",", attribute.stream().map(DayOfWeek::name).toArray(String[]::new));
+	}
+
+	@Override
+	public Set<DayOfWeek> convertToEntityAttribute(String dbData) {
+		return new HashSet<>(Arrays.asList(dbData.split(",")))
+			.stream()
+			.map(DayOfWeek::valueOf)
+			.collect(Collectors.toSet());
+	}
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/domain/Routine.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/domain/Routine.java
@@ -1,12 +1,15 @@
 package site.coach_coach.coach_coach_server.routine.domain;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,7 +18,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -26,7 +28,8 @@ import lombok.NoArgsConstructor;
 import site.coach_coach.coach_coach_server.action.domain.Action;
 import site.coach_coach.coach_coach_server.coach.domain.Coach;
 import site.coach_coach.coach_coach_server.common.domain.DateEntity;
-import site.coach_coach.coach_coach_server.repeatdate.domain.RepeatDate;
+import site.coach_coach.coach_coach_server.routine.converter.DayOfWeekSetConverter;
+import site.coach_coach.coach_coach_server.routine.dto.UpdateRoutineInfoRequest;
 import site.coach_coach.coach_coach_server.sport.domain.Sport;
 import site.coach_coach.coach_coach_server.user.domain.User;
 
@@ -75,12 +78,15 @@ public class Routine extends DateEntity {
 	@OneToMany(mappedBy = "routine")
 	private List<Action> actions;
 
-	@OneToOne(mappedBy = "routine")
-	private RepeatDate repeatDate;
+	@NotNull
+	@Column(name = "repeat_date")
+	@Convert(converter = DayOfWeekSetConverter.class)
+	private Set<DayOfWeek> repeats;
 
-	public void updateRoutineInfo(String routineName, Sport sport) {
-		this.routineName = routineName;
+	public void updateRoutineInfo(UpdateRoutineInfoRequest updateRoutineInfoRequest, Sport sport) {
+		this.routineName = updateRoutineInfoRequest.routineName();
 		this.sport = sport;
+		this.repeats = updateRoutineInfoRequest.repeats();
 	}
 
 	public void changeIsCompleted() {

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/CreateRoutineRequest.java
@@ -1,6 +1,8 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,7 +19,7 @@ public record CreateRoutineRequest(
 	Long sportId,
 
 	@NotNull
-	String[] repeats,
+	Set<DayOfWeek> repeats,
 
 	List<ActionDto> actions
 ) {

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineDto.java
@@ -1,6 +1,8 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.validation.constraints.NotNull;
@@ -20,12 +22,15 @@ public record RoutineDto(
 	String sportName,
 
 	@NotNull
+	Set<DayOfWeek> repeats,
+
+	@NotNull
 	Boolean isCompleted,
 
 	List<ActionDto> actions
 
 ) {
-	public static RoutineDto from(Routine routine) {
+	public static RoutineDto convertToDtoWithoutNullAction(Routine routine) {
 		List<ActionDto> actions = routine.getActions().stream()
 			.filter(action -> action.getActionName() != null)
 			.map(ActionDto::from)
@@ -35,6 +40,7 @@ public record RoutineDto(
 			routine.getRoutineId(),
 			routine.getRoutineName(),
 			routine.getSport().getSportName(),
+			routine.getRepeats(),
 			routine.getIsCompleted(),
 			actions
 		);

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineListDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/RoutineListDto.java
@@ -5,10 +5,10 @@ import java.util.List;
 public record RoutineListDto(
 	float completionPercentage,
 
-	List<RoutineDto> routines
+	List<RoutineDto> routineDtos
 ) {
 	public RoutineListDto setCompletionPercentage(float completionPercentage) {
 
-		return new RoutineListDto(Math.round(completionPercentage * 100) / 100.0f, this.routines);
+		return new RoutineListDto(completionPercentage, this.routineDtos);
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UpdateRoutineInfoRequest.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/routine/dto/UpdateRoutineInfoRequest.java
@@ -1,6 +1,8 @@
 package site.coach_coach.coach_coach_server.routine.dto;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,7 +19,7 @@ public record UpdateRoutineInfoRequest(
 	Long sportId,
 
 	@NotNull
-	String[] repeats,
+	Set<DayOfWeek> repeats,
 
 	List<ActionDto> actions
 ) {

--- a/src/main/resources/db/migration/V20__delete_repeat_dates_table.sql
+++ b/src/main/resources/db/migration/V20__delete_repeat_dates_table.sql
@@ -1,0 +1,6 @@
+-- repeat_dates 테이블 삭제 --
+drop table `coachcoach`.`repeat_dates`;
+
+-- routines 테이블에 repeat_date 컬럼 추가 --
+alter table `coachcoach`.`routines`
+ADD COLUMN `repeat_date` SET('MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY') NOT NULL AFTER `is_deleted`;

--- a/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/site/coach_coach/coach_coach_server/routine/controller/RoutineControllerTest.java
@@ -4,8 +4,11 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 
+import java.time.DayOfWeek;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -88,7 +91,9 @@ public class RoutineControllerTest {
 			.isDeleted(false)
 			.actions(new ArrayList<>())
 			.build();
-		routineDto = new RoutineDto(1L, "RoutineName", "SportName", false, new ArrayList<>());
+		Set<DayOfWeek> repeats = new HashSet<DayOfWeek>();
+		repeats.add(DayOfWeek.MONDAY);
+		routineDto = new RoutineDto(1L, "RoutineName", "SportName", repeats, false, new ArrayList<>());
 		routineListDto = new RoutineListDto(0.7f, List.of(routineDto));
 		userInfoForRoutineList = new UserInfoForRoutineList(1L, "nickname", "profileImageUrl");
 	}
@@ -158,7 +163,8 @@ public class RoutineControllerTest {
 		// Given
 		Long userIdByJwt = 1L;
 		Long routineId = 1L;
-		String[] repeats = {"MONDAY"};
+		Set<DayOfWeek> repeats = new HashSet<DayOfWeek>();
+		repeats.add(DayOfWeek.MONDAY);
 		CreateRoutineRequest createRoutineRequest =
 			new CreateRoutineRequest(2L, "routineName", 1L, repeats, new ArrayList<>());
 
@@ -184,7 +190,8 @@ public class RoutineControllerTest {
 	public void createdRoutineFailTest() throws Exception {
 		// Given
 		Long userIdByJwt = 1L;
-		String[] repeats = {"MONDAY"};
+		Set<DayOfWeek> repeats = new HashSet<DayOfWeek>();
+		repeats.add(DayOfWeek.MONDAY);
 		CreateRoutineRequest createRoutineRequest =
 			new CreateRoutineRequest(null, "  ", 1L, repeats, new ArrayList<>());
 


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 루틴의 반복일자 기능을 구현했습니다.
- 루틴 생성 시, 반복일자 설정이 가능합니다.
- 루틴 수정 시, 반복일자 수정이 가능합니다.
- 루틴 조회 시, 반복일자로 설정된 날에만 조회가 가능합니다.

### PR Point
- DB에서 SET타입을 통해 하나의 루틴에서 반복일자라는 다수의 정보를 하나의 row로 취급하고 있기에 추가 테이블을 사용하는 것이 아닌, 
   컬럼을 추가하는 것으로도 같은 목적을 달성할 수 있다고 판단하여 DB구조를 변경하였습니다.
- RoutineDto의 기존 from 메서드의 이름 수정
  -  단순히 엔티티를 DTO로 변환하는 역할이 아닌, 각 루틴내의 운동목록 중에 비어있는 운동을 필터링하여 가져오고 있기 때문에 메서드의 역할을 확실히 표현하기위해 메서드명을 수정하였습니다.
- 앞으로 루틴 생성, 수정의 경우에 repeats : ["MONDAY", "FRIDAY"] 와 같은 속성도 RequestBody에 추가해주셔야 합니다!
   V20 sql 파일 실행 전에 로컬 DB에 기존 루틴이 존재한다면 모두 비우고 실행해주시면 감사하겠습니다!

closed #339 
