### PR TITLE
refactor(coach) : 문의/매칭 리스트 반환 데이터 수정 및 추가

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/MatchingCoachResponseDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/MatchingCoachResponseDto.java
@@ -1,9 +1,16 @@
 package site.coach_coach.coach_coach_server.coach.dto;
 
+import java.util.List;
+
+import site.coach_coach.coach_coach_server.sport.dto.CoachingSportDto;
+
 public record MatchingCoachResponseDto(
 	Long coachId,
 	String coachName,
 	String profileImageUrl,
+	String localAddress,
+	List<CoachingSportDto> coachingSports,
+	boolean isLiked,
 	boolean isMatching
 ) {
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/MatchingUserResponseDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/MatchingUserResponseDto.java
@@ -1,13 +1,18 @@
 package site.coach_coach.coach_coach_server.coach.dto;
 
+import java.util.List;
+
 import lombok.Builder;
+import site.coach_coach.coach_coach_server.sport.dto.InterestedSportDto;
 
 @Builder
 public record MatchingUserResponseDto(
 	Long userId,
 	String userName,
 	String profileImageUrl,
+	String localAddress,
+	List<InterestedSportDto> interestedSports,
+	String startDate,
 	boolean isMatching
-
 ) {
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 문의/매칭 리스트 조회 시 전달되는 response 값 추가 
  - 코치 리스트 조회 : 주소, 코칭 종목, 관심 여부
  - 회원 리스트 조회 : 주소, 관심 종목, 문의/매칭 날짜
- 날짜 및 시간 포맷 통일 (yyyy-MM-dd'T'HH:mm:ss 형식 적용)

### PR Point
- 회원 리스트 조회의 startDate는 
  - 문의 회원일 경우, 새로운 row 추가되고 is_matching값이 0 -> 문의 날짜
  - 매칭 회원일 경우, is_matching 값이 1 -> 매칭 날짜
가 각각 필요하여 코드 상에서 구분하여 분기처리를 할까 했으나, updated_at 값으로 통일하기로 함.

### 📸 스크린샷
|사진|설명|
|--|--|
|![image](https://github.com/user-attachments/assets/e8a42fbf-a3c6-4b65-b424-24a94cbf5704)|문의/매칭 회원 조회|
|![image](https://github.com/user-attachments/assets/e6a5d1ec-ff58-4d74-bca7-bbf4fb920bda)|문의/매칭 코치 조회|

closed #327 