### PR TITLE
refactor(userRecord): 신체 정보 입력 및 수정 api 로직 수정

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
@@ -1,7 +1,9 @@
 package site.coach_coach.coach_coach_server.userrecord.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -60,6 +62,17 @@ public class UserRecordController {
 		return ResponseEntity.ok(new SuccessIdResponse(recordId));
 	}
 
+	@PostMapping("/v2/records")
+	public ResponseEntity<Void> addBodyInfoToUserRecordV2(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestParam(name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate recordDate,
+		@RequestBody @Valid UserRecordUpdateRequest userRecordupdateRequest
+	) {
+		Long userId = userDetails.getUserId();
+		userRecordService.upsertBodyInfoToUserRecord(userId, recordDate, userRecordupdateRequest);
+		return ResponseEntity.noContent().build();
+	}
+
 	@GetMapping("/v1/records")
 	public ResponseEntity<UserRecordResponse> getUserRecordsWithCompletionStatus(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
@@ -84,6 +97,7 @@ public class UserRecordController {
 	@GetMapping("/v1/records/charts")
 	public ResponseEntity<List<BodyInfoChartResponse>> getBodyInfoCharts(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestParam(name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate recordDate,
 		@RequestParam(name = "type") @NotBlank String type
 	) {
 		Long userId = userDetails.getUserId();

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
@@ -65,12 +65,12 @@ public class UserRecordController {
 	@PostMapping("/v2/records")
 	public ResponseEntity<Void> addBodyInfoToUserRecordV2(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate recordDate,
+		@RequestParam(name = "record_date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate recordDate,
 		@RequestBody @Valid UserRecordUpdateRequest userRecordupdateRequest
 	) {
 		Long userId = userDetails.getUserId();
 		userRecordService.upsertBodyInfoToUserRecord(userId, recordDate, userRecordupdateRequest);
-		return ResponseEntity.noContent().build();
+		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
 	@GetMapping("/v1/records")

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/controller/UserRecordController.java
@@ -97,7 +97,6 @@ public class UserRecordController {
 	@GetMapping("/v1/records/charts")
 	public ResponseEntity<List<BodyInfoChartResponse>> getBodyInfoCharts(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate recordDate,
 		@RequestParam(name = "type") @NotBlank String type
 	) {
 		Long userId = userDetails.getUserId();

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
@@ -97,20 +97,19 @@ public class UserRecordService {
 		LocalDate recordDate,
 		UserRecordUpdateRequest userRecordUpdateRequest
 	) {
-		UserRecord userRecord = userRecordRepository.findByRecordDateAndUser_UserId(recordDate, userId)
-			.orElse(null);
-
-		if (userRecord == null) {
-			userRecord = buildNewUserRecord(userId, recordDate, userRecordUpdateRequest);
-			userRecordRepository.save(userRecord);
-		} else {
-			userRecord.updateBodyInfo(
-				userRecordUpdateRequest.weight(),
-				userRecordUpdateRequest.skeletalMuscle(),
-				userRecordUpdateRequest.fatPercentage(),
-				userRecordUpdateRequest.bmi()
+		userRecordRepository.findByRecordDateAndUser_UserId(recordDate, userId)
+			.ifPresentOrElse(
+				userRecord -> userRecord.updateBodyInfo(
+					userRecordUpdateRequest.weight(),
+					userRecordUpdateRequest.skeletalMuscle(),
+					userRecordUpdateRequest.fatPercentage(),
+					userRecordUpdateRequest.bmi()
+				),
+				() -> {
+					UserRecord newUserRecord = buildNewUserRecord(userId, recordDate, userRecordUpdateRequest);
+					userRecordRepository.save(newUserRecord);
+				}
 			);
-		}
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/userrecord/service/UserRecordService.java
@@ -91,6 +91,28 @@ public class UserRecordService {
 		);
 	}
 
+	@Transactional
+	public void upsertBodyInfoToUserRecord(
+		Long userId,
+		LocalDate recordDate,
+		UserRecordUpdateRequest userRecordUpdateRequest
+	) {
+		UserRecord userRecord = userRecordRepository.findByRecordDateAndUser_UserId(recordDate, userId)
+			.orElse(null);
+
+		if (userRecord == null) {
+			userRecord = buildNewUserRecord(userId, recordDate, userRecordUpdateRequest);
+			userRecordRepository.save(userRecord);
+		} else {
+			userRecord.updateBodyInfo(
+				userRecordUpdateRequest.weight(),
+				userRecordUpdateRequest.skeletalMuscle(),
+				userRecordUpdateRequest.fatPercentage(),
+				userRecordUpdateRequest.bmi()
+			);
+		}
+	}
+
 	@Transactional(readOnly = true)
 	public UserRecordResponse getUserRecordsByUserAndPeriod(Long userId, Integer year, Integer month) {
 		LocalDate startDate = LocalDate.of(year, month, 1);
@@ -172,6 +194,24 @@ public class UserRecordService {
 					.build();
 				return userRecordRepository.save(userRecord);
 			});
+	}
+
+	private UserRecord buildNewUserRecord(
+		Long userId,
+		LocalDate recordDate,
+		UserRecordUpdateRequest userRecordUpdateRequest
+	) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		return UserRecord.builder()
+			.user(user)
+			.weight(userRecordUpdateRequest.weight())
+			.skeletalMuscle(userRecordUpdateRequest.skeletalMuscle())
+			.fatPercentage(userRecordUpdateRequest.fatPercentage())
+			.bmi(userRecordUpdateRequest.bmi())
+			.recordDate(recordDate)
+			.build();
 	}
 
 	private LocalDate validateAndConvertToLocalDate(String date) {


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 신체 정보 입력 및 수정 api를 리팩토링 하였습니다.
- 기존에는 두 개의 api로 나눴으나 한 api를 호출하도록 수정하였습니다.
- 쿼리 파라미터로 date를 받고 userId와 date를 통해 데이터를 추가합니다.

### 📸 스크린샷

|사진|설명|
|---|---|
|![image](https://github.com/user-attachments/assets/3e062caa-e4e3-4b7b-8ea1-4e6cef846c24)| api 호출 성공 |
|![image](https://github.com/user-attachments/assets/932fd975-98cf-48d5-a3c7-1b5403eb1f9b)|db에 추가|

closed #346 
