### PR TITLE
refactor(coachDetail) : 코치 상세 조회 api response 변경

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/domain/Coach.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/domain/Coach.java
@@ -65,6 +65,10 @@ public class Coach extends DateEntity {
 	@Column(name = "is_open")
 	private Boolean isOpen;
 
+	@NotNull
+	@Column(name = "total_user_count", nullable = false)
+	private int totalUserCount = 0;
+
 	@OneToMany(mappedBy = "coach")
 	private List<CoachingSport> coachingSports;
 
@@ -81,6 +85,10 @@ public class Coach extends DateEntity {
 		this.isOpen = isOpen;
 	}
 
+	public void increaseTotalUserCount() {
+		this.totalUserCount += 1;
+	}
+
 	public Coach(User user) {
 		this.user = user;
 		this.coachIntroduction = "";
@@ -89,5 +97,6 @@ public class Coach extends DateEntity {
 		this.activeHours = "";
 		this.chattingUrl = "";
 		this.isOpen = true;
+		this.totalUserCount = 0;
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDetailDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDetailDto.java
@@ -20,7 +20,6 @@ public record CoachDetailDto(
 	String localAddress,
 	@NotNull
 	String profileImageUrl,
-	String createdAt,
 	@NotNull
 	String coachIntroduction,
 	@NotNull
@@ -32,14 +31,13 @@ public record CoachDetailDto(
 	@NotNull
 	@Size(max = 500)
 	String chattingUrl,
-	List<ReviewDto> reviews,
 	@NotNull
 	boolean isOpen,
 	boolean isContacted,
 	boolean isMatched,
-	int countOfReviews,
-	double reviewRating,
 	boolean isLiked,
-	int countOfLikes
+	boolean isSelf,
+	double reviewRating,
+	int totalUserCount
 ) {
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -197,7 +197,6 @@ public class CoachService {
 		boolean isLiked = isLikedByUser(user, coach);
 		boolean isContacted = matchingRepository.existsByUserUserIdAndCoachCoachId(user.getUserId(), coachId);
 
-
 		List<CoachingSportDto> coachingSports = getCoachingSports(coach);
 		boolean isMatched = matchingRepository.existsByUserUserIdAndCoachCoachIdAndIsMatching(
 			user.getUserId(), coach.getCoachId(), true);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -197,7 +197,6 @@ public class CoachService {
 		boolean isLiked = isLikedByUser(user, coach);
 		boolean isContacted = matchingRepository.existsByUserUserIdAndCoachCoachId(user.getUserId(), coachId);
 
-		int countOfLikes = getCountOfLikes(coach);
 
 		List<CoachingSportDto> coachingSports = getCoachingSports(coach);
 		boolean isMatched = matchingRepository.existsByUserUserIdAndCoachCoachIdAndIsMatching(
@@ -209,21 +208,19 @@ public class CoachService {
 			.coachGender(coach.getUser().getGender())
 			.localAddress(coach.getUser().getLocalAddress())
 			.profileImageUrl(coach.getUser().getProfileImageUrl())
-			.createdAt(coach.getCreatedAt().toString())
 			.coachIntroduction(coach.getCoachIntroduction())
 			.coachingSports(coachingSports)
 			.activeCenter(coach.getActiveCenter())
 			.activeCenterDetail(coach.getActiveCenterDetail())
 			.activeHours(coach.getActiveHours())
 			.chattingUrl(coach.getChattingUrl())
-			.reviews(reviews)
 			.isOpen(coach.getIsOpen())
 			.isContacted(isContacted)
 			.isMatched(isMatched)
-			.countOfReviews(reviews.size())
-			.reviewRating(averageRating)
 			.isLiked(isLiked)
-			.countOfLikes(countOfLikes)
+			.isSelf(isSelf)
+			.reviewRating(averageRating)
+			.totalUserCount(coach.getTotalUserCount())
 			.build();
 	}
 
@@ -528,6 +525,7 @@ public class CoachService {
 		}
 
 		matching.markAsMatched();
+		coach.increaseTotalUserCount();
 		notificationService.createNotification(userId, coach.getCoachId(), RelationFunctionEnum.match);
 	}
 }

--- a/src/main/resources/db/migration/V22_add_total_user_count_column.sql
+++ b/src/main/resources/db/migration/V22_add_total_user_count_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `coachcoach`.`coaches`
+    ADD COLUMN `total_user_count` INT NOT NULL DEFAULT ０ AFTER `is_open`;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 매칭 회원 등록 시 누적 회원 수 증가 로직 추가
  - 회원이 코치와 매칭이 될 때마다 해당 코치의 `total_user_count` 필드 값이 자동으로 증가하도록 로직을 구현함
  - `coaches` 테이블에 `total_user_count` 컬럼 추가
- 코치 상세 조회 시 반환되는 Response 값 변경
  - 변경에 디자인에 사용되지 않는 `createdAt`, `countOfReviews`, `countOfLikes` 삭제
  - 리뷰 api를 따로 분리하게 되면서 리뷰와 관련된 컬럼들 삭제
  - 본인인지 구분하기 위한 `isSelf` 컬럼 추가(프론트 요청)
  - 누적회원수 `totalUserCount` 추가

### 📸 스크린샷
|사진|설명|
|--|--|
|![image](https://github.com/user-attachments/assets/0813bfc4-8472-4050-9f21-e022f527f9c7)|코치 상세 정보 조회|

closed #334
