### PR TITLE
feat(review) : 리뷰 조회 및 정렬 API 구현

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -23,11 +23,13 @@ import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
 import site.coach_coach.coach_coach_server.coach.dto.CoachRequest;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingCoachResponseDto;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingUserResponseDto;
+import site.coach_coach.coach_coach_server.coach.dto.ReviewListDto;
 import site.coach_coach.coach_coach_server.coach.dto.ReviewRequestDto;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
 import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
 import site.coach_coach.coach_coach_server.common.exception.UserNotFoundException;
 import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
+import site.coach_coach.coach_coach_server.review.dto.ReviewSortOption;
 import site.coach_coach.coach_coach_server.user.domain.User;
 
 @RestController
@@ -154,6 +156,17 @@ public class CoachController {
 		List<MatchingCoachResponseDto> matchingCoaches = coachService.getMatchingCoachesByUserId(userId);
 
 		return ResponseEntity.ok(matchingCoaches);
+	}
+
+	@GetMapping("/v1/coaches/reviews")
+	public ResponseEntity<ReviewListDto> getReviews(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestParam(name = "coachId", required = false) Long coachId,
+		@RequestParam(required = false, defaultValue = "LATEST") ReviewSortOption sortOption) {
+		User user = userDetails.getUser();
+		ReviewListDto reviewList = coachService.getAllReviews(user, coachId, sortOption);
+
+		return ResponseEntity.ok(reviewList);
 	}
 
 	@PostMapping("/v1/coaches/{coachId}/reviews")

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/ReviewListDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/ReviewListDto.java
@@ -1,0 +1,16 @@
+package site.coach_coach.coach_coach_server.coach.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import site.coach_coach.coach_coach_server.review.dto.ReviewDto;
+
+@Builder
+public record ReviewListDto(
+	List<ReviewDto> reviews,
+	int countOfReviews,
+	double reviewRating,
+	boolean isMatched,
+	boolean isOpen
+) {
+}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -24,6 +24,7 @@ import site.coach_coach.coach_coach_server.coach.dto.CoachListResponse;
 import site.coach_coach.coach_coach_server.coach.dto.CoachRequest;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingCoachResponseDto;
 import site.coach_coach.coach_coach_server.coach.dto.MatchingUserResponseDto;
+import site.coach_coach.coach_coach_server.coach.dto.ReviewListDto;
 import site.coach_coach.coach_coach_server.coach.dto.ReviewRequestDto;
 import site.coach_coach.coach_coach_server.coach.repository.CoachRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
@@ -40,6 +41,7 @@ import site.coach_coach.coach_coach_server.matching.repository.MatchingRepositor
 import site.coach_coach.coach_coach_server.notification.service.NotificationService;
 import site.coach_coach.coach_coach_server.review.domain.Review;
 import site.coach_coach.coach_coach_server.review.dto.ReviewDto;
+import site.coach_coach.coach_coach_server.review.dto.ReviewSortOption;
 import site.coach_coach.coach_coach_server.review.repository.ReviewRepository;
 import site.coach_coach.coach_coach_server.sport.domain.CoachingSport;
 import site.coach_coach.coach_coach_server.sport.domain.Sport;
@@ -191,7 +193,7 @@ public class CoachService {
 			throw new AccessDeniedException();
 		}
 
-		List<ReviewDto> reviews = getReviews(coach, user);
+		List<ReviewDto> reviews = getReviews(coach, user, ReviewSortOption.LATEST);
 		double averageRating = calculateAverageRating(reviews);
 
 		boolean isLiked = isLikedByUser(user, coach);
@@ -466,9 +468,34 @@ public class CoachService {
 			.build();
 	}
 
+	@Transactional
+	public ReviewListDto getAllReviews(User user, Long coachId, ReviewSortOption sortOption) {
+		Coach coach = (coachId != null) ? getCoachById(coachId) : getCoachByUserId(user.getUserId());
+
+		boolean isSelf = user.getUserId().equals(coach.getUser().getUserId());
+
+		if (!isSelf && !coach.getIsOpen()) {
+			throw new AccessDeniedException();
+		}
+
+		List<ReviewDto> reviews = getReviews(coach, user, sortOption);
+		double averageRating = calculateAverageRating(reviews);
+
+		boolean isMatched = matchingRepository.existsByUserUserIdAndCoachCoachIdAndIsMatching(
+			user.getUserId(), coach.getCoachId(), true);
+
+		return ReviewListDto.builder()
+			.reviews(reviews)
+			.countOfReviews(reviews.size())
+			.reviewRating(averageRating)
+			.isMatched(isMatched)
+			.isOpen(coach.getIsOpen())
+			.build();
+	}
+
 	@Transactional(readOnly = true)
-	public List<ReviewDto> getReviews(Coach coach, User currentUser) {
-		return reviewRepository.findByCoach_CoachId(coach.getCoachId()).stream()
+	public List<ReviewDto> getReviews(Coach coach, User currentUser, ReviewSortOption sortOption) {
+		List<ReviewDto> reviews = reviewRepository.findByCoach_CoachId(coach.getCoachId()).stream()
 			.map(review -> new ReviewDto(
 				review.getReviewId(),
 				review.getUserId(),
@@ -480,7 +507,30 @@ public class CoachService {
 					.map(user -> user.getUserId().equals(currentUser.getUserId()))
 					.orElse(false)
 			))
-			.sorted(Comparator.comparing(ReviewDto::createdAt).reversed())
+			.collect(Collectors.toList());
+
+		return sortReviews(reviews, sortOption);
+	}
+
+	private List<ReviewDto> sortReviews(List<ReviewDto> reviews, ReviewSortOption sortOption) {
+		Comparator<ReviewDto> comparator;
+
+		switch (sortOption) {
+			case RATING_ASC:
+				comparator = Comparator.comparing(ReviewDto::stars).reversed()
+					.thenComparing(ReviewDto::createdAt).reversed();
+				break;
+			case RATING_DESC:
+				comparator = Comparator.comparing(ReviewDto::stars)
+					.thenComparing(ReviewDto::createdAt).reversed();
+				break;
+			case LATEST:
+			default:
+				comparator = Comparator.comparing(ReviewDto::createdAt).reversed();
+		}
+
+		return reviews.stream()
+			.sorted(comparator)
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -513,21 +513,13 @@ public class CoachService {
 	}
 
 	private List<ReviewDto> sortReviews(List<ReviewDto> reviews, ReviewSortOption sortOption) {
-		Comparator<ReviewDto> comparator;
-
-		switch (sortOption) {
-			case RATING_ASC:
-				comparator = Comparator.comparing(ReviewDto::stars).reversed()
-					.thenComparing(ReviewDto::createdAt).reversed();
-				break;
-			case RATING_DESC:
-				comparator = Comparator.comparing(ReviewDto::stars)
-					.thenComparing(ReviewDto::createdAt).reversed();
-				break;
-			case LATEST:
-			default:
-				comparator = Comparator.comparing(ReviewDto::createdAt).reversed();
-		}
+		Comparator<ReviewDto> comparator = switch (sortOption) {
+			case RATING_ASC -> Comparator.comparing(ReviewDto::stars).reversed()
+				.thenComparing(ReviewDto::createdAt).reversed();
+			case RATING_DESC -> Comparator.comparing(ReviewDto::stars)
+				.thenComparing(ReviewDto::createdAt).reversed();
+			case LATEST -> Comparator.comparing(ReviewDto::createdAt).reversed();
+		};
 
 		return reviews.stream()
 			.sorted(comparator)

--- a/src/main/java/site/coach_coach/coach_coach_server/review/dto/ReviewSortOption.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/review/dto/ReviewSortOption.java
@@ -1,0 +1,8 @@
+package site.coach_coach.coach_coach_server.review.dto;
+
+public enum ReviewSortOption {
+	LATEST,       // 최신 순
+	RATING_DESC,  // 별점 높은 순
+	RATING_ASC    // 별점 낮은 순
+
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 리뷰 조회 API 개선
  - 기존 코치 상세 정보 조회 API로 전달되었던 리뷰 데이터를 따로 분리
  - 리뷰 조회 API에 정렬 기능을 추가하여 리뷰를 최신순, 별점 높은 순, 별점 낮은 순 조회 기능 구현
  - Query Parameter를 통해 정렬 옵션을 받아 동적으로 정렬이 가능하도록 구현
  - `sortOption?`: `LATEST` | `RATING_DESC` | `RATING_ASC` // 최신순 (디폴트) | 별점 높은 순 | 별점 낮은 순

- 정렬 로직 개선
  - `sortReviews()` 메서드를 추가하여 `ReviewSortOption`에 따라 동적으로 리뷰 정렬
  - `getReviews()` 메서드에서 정렬 로직을 분리하고, `ReviewSortOption Enum`을 활용함
  - 코드 중복을 줄이기 위해 `Comparator`를 동적으로 생성함

### 📸 스크린샷
|사진|설명|
|--|--|
|![image](https://github.com/user-attachments/assets/e3ce4a9c-7c5b-4f8d-a18d-da1bc685af37)![image](https://github.com/user-attachments/assets/ef34a669-98e2-4995-8388-4a2e5a99bdb5)| 최신순 `sortOption=LATEST` |
|![image](https://github.com/user-attachments/assets/d7fffc8c-f324-4af7-9f32-3e538446890d)![image](https://github.com/user-attachments/assets/be65cfcd-dfc3-4606-8fc7-8881f6c0ec04)| 별점 높은 순 `sortOption=RATING_DESC` |
|![image](https://github.com/user-attachments/assets/3bdfe2cd-f6a6-45d2-b056-f2e62e231cfc)![image](https://github.com/user-attachments/assets/f6077f88-ad73-4f58-a891-9b852041a5d6)| 별점 낮은 순 `sortOption=RATING_ASC` |


closed #353
