### PR TITLE
refactor(coachList) : 코치 성별 필터 추가

### DIFF
--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -27,6 +27,7 @@ import site.coach_coach.coach_coach_server.coach.dto.ReviewListDto;
 import site.coach_coach.coach_coach_server.coach.dto.ReviewRequestDto;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
 import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
+import site.coach_coach.coach_coach_server.common.domain.GenderEnum;
 import site.coach_coach.coach_coach_server.common.exception.UserNotFoundException;
 import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.review.dto.ReviewSortOption;
@@ -68,17 +69,15 @@ public class CoachController {
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(required = false) String sports,
 		@RequestParam(required = false) String search,
+		@RequestParam(required = false) String gender,
 		@RequestParam(required = false) Boolean latest,
 		@RequestParam(required = false) Boolean review,
 		@RequestParam(required = false) Boolean liked,
 		@RequestParam(required = false) Boolean my
 	) {
-		if (userDetails == null || userDetails.getUser() == null) {
-			throw new UserNotFoundException();
-		}
-
 		User user = userDetails.getUser();
-		CoachListResponse response = coachService.getAllCoaches(user, page, sports, search, latest, review, liked, my);
+		CoachListResponse response;
+		response = coachService.getAllCoaches(user, page, sports, search, gender, latest, review, liked, my);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/controller/CoachController.java
@@ -27,8 +27,6 @@ import site.coach_coach.coach_coach_server.coach.dto.ReviewListDto;
 import site.coach_coach.coach_coach_server.coach.dto.ReviewRequestDto;
 import site.coach_coach.coach_coach_server.coach.service.CoachService;
 import site.coach_coach.coach_coach_server.common.constants.SuccessMessage;
-import site.coach_coach.coach_coach_server.common.domain.GenderEnum;
-import site.coach_coach.coach_coach_server.common.exception.UserNotFoundException;
 import site.coach_coach.coach_coach_server.common.response.SuccessResponse;
 import site.coach_coach.coach_coach_server.review.dto.ReviewSortOption;
 import site.coach_coach.coach_coach_server.user.domain.User;

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDetailDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/CoachDetailDto.java
@@ -38,6 +38,7 @@ public record CoachDetailDto(
 	boolean isLiked,
 	boolean isSelf,
 	double reviewRating,
+	int countOfReviews,
 	int totalUserCount
 ) {
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/dto/PopularCoachDto.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/dto/PopularCoachDto.java
@@ -17,6 +17,7 @@ public record PopularCoachDto(
 	@NotBlank
 	String description,
 	int countOfLikes,
+	double reviewRating,
 	boolean isLiked,
 	List<CoachingSportDto> coachingSports
 ) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import jakarta.validation.constraints.NotNull;
 import site.coach_coach.coach_coach_server.coach.domain.Coach;
+import site.coach_coach.coach_coach_server.common.domain.GenderEnum;
 import site.coach_coach.coach_coach_server.user.domain.User;
 
 @Repository
@@ -32,10 +33,12 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "LEFT JOIN c.reviews r "
 		+ "WHERE (:sports IS NULL OR cs.sport.sportId IN :sports) "
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
+		+ "AND (:genderEnum IS NULL OR c.user.gender = :genderEnum) "
 		+ "GROUP BY c.coachId "
 		+ "ORDER BY c.updatedAt DESC")
 	Page<Coach> findAllWithLatestSorted(@Param("sports") List<Long> sports,
 		@Param("search") String search,
+		@Param("genderEnum") GenderEnum genderEnum,
 		Pageable pageable);
 
 	@Query("SELECT c FROM Coach c "
@@ -43,10 +46,12 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "LEFT JOIN c.reviews r "
 		+ "WHERE (:sports IS NULL OR cs.sport.sportId IN :sports) "
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
+		+ "AND (:genderEnum IS NULL OR c.user.gender = :genderEnum) "
 		+ "GROUP BY c.coachId "
 		+ "ORDER BY COUNT(r) DESC")
 	Page<Coach> findAllWithReviewsSorted(@Param("sports") List<Long> sports,
 		@Param("search") String search,
+		@Param("genderEnum") GenderEnum genderEnum,
 		Pageable pageable);
 
 	@Query("SELECT c FROM Coach c "
@@ -54,10 +59,12 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "LEFT JOIN c.reviews r "
 		+ "WHERE (:sports IS NULL OR cs.sport.sportId IN :sports) "
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
+		+ "AND (:genderEnum IS NULL OR c.user.gender = :genderEnum) "
 		+ "GROUP BY c.coachId "
 		+ "ORDER BY (SELECT COUNT(ucl) FROM UserCoachLike ucl WHERE ucl.coach.coachId = c.coachId) DESC")
 	Page<Coach> findAllWithLikesSorted(@Param("sports") List<Long> sports,
 		@Param("search") String search,
+		@Param("genderEnum") GenderEnum genderEnum,
 		Pageable pageable);
 
 	@Query("SELECT c FROM Coach c "
@@ -67,13 +74,16 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		+ "WHERE ucl.user.userId = :userId "
 		+ "AND (:sports IS NULL OR cs.sport.sportId IN :sports) "
 		+ "AND (:search IS NULL OR c.user.nickname LIKE %:search%) "
+		+ "AND (:genderEnum IS NULL OR c.user.gender = :genderEnum) "
 		+ "GROUP BY c.coachId "
 		+ "ORDER BY c.updatedAt DESC")
 	Page<Coach> findMyCoaches(
 		@Param("userId") Long userId,
 		@Param("sports") List<Long> sports,
 		@Param("search") String search,
+		@Param("genderEnum") GenderEnum genderEnum,
 		Pageable pageable);
+
 
 	boolean existsByUser(User user);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/repository/CoachRepository.java
@@ -84,6 +84,4 @@ public interface CoachRepository extends JpaRepository<Coach, Long> {
 		@Param("genderEnum") GenderEnum genderEnum,
 		Pageable pageable);
 
-
-	boolean existsByUser(User user);
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -445,7 +445,7 @@ public class CoachService {
 		try {
 			return GenderEnum.valueOf(gender.toUpperCase());
 		} catch (IllegalArgumentException e) {
-			throw new IllegalArgumentException("Invalid gender value: " + gender);
+			throw new IllegalArgumentException(ErrorMessage.INVALID_REQUEST);
 		}
 	}
 

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -222,6 +222,7 @@ public class CoachService {
 			.isLiked(isLiked)
 			.isSelf(isSelf)
 			.reviewRating(averageRating)
+			.countOfReviews(reviews.size())
 			.totalUserCount(coach.getTotalUserCount())
 			.build();
 	}

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -28,6 +28,7 @@ import site.coach_coach.coach_coach_server.coach.dto.ReviewListDto;
 import site.coach_coach.coach_coach_server.coach.dto.ReviewRequestDto;
 import site.coach_coach.coach_coach_server.coach.repository.CoachRepository;
 import site.coach_coach.coach_coach_server.common.constants.ErrorMessage;
+import site.coach_coach.coach_coach_server.common.domain.GenderEnum;
 import site.coach_coach.coach_coach_server.common.domain.RelationFunctionEnum;
 import site.coach_coach.coach_coach_server.common.exception.AccessDeniedException;
 import site.coach_coach.coach_coach_server.common.exception.DuplicateValueException;
@@ -226,8 +227,8 @@ public class CoachService {
 	}
 
 	@Transactional(readOnly = true)
-	public CoachListResponse getAllCoaches(User user, int page, String sports, String search, Boolean latest,
-		Boolean review, Boolean liked, Boolean my) {
+	public CoachListResponse getAllCoaches(User user, int page, String sports, String search, String gender,
+		Boolean latest, Boolean review, Boolean liked, Boolean my) {
 
 		List<Long> allSportsIds = sportRepository.findAllSportIds();
 
@@ -237,11 +238,14 @@ public class CoachService {
 		List<Long> sportsList = (sports != null && !sports.isEmpty()) ? parseSports(sports) : allSportsIds;
 		sportsList = getExistingSportsList(sportsList);
 
+		GenderEnum genderEnum = parseGender(gender);
+
 		if (sportsList.isEmpty() && (sports != null && !sports.isEmpty())) {
 			return new CoachListResponse(List.of(), 0, page);
 		}
 
-		Page<Coach> coachesPage = fetchCoachesPage(user, sportsList, search, pageable, review, liked, latest, my);
+		Page<Coach> coachesPage;
+		coachesPage = fetchCoachesPage(user, sportsList, search, genderEnum, pageable, review, liked, latest, my);
 
 		if (coachesPage.isEmpty() && page == 1) {
 			return new CoachListResponse(List.of(), 0, page);
@@ -411,20 +415,20 @@ public class CoachService {
 			.collect(Collectors.toList());
 	}
 
-	private Page<Coach> fetchCoachesPage(User user, List<Long> sportsList, String search, Pageable pageable,
-		Boolean review, Boolean liked, Boolean latest, Boolean my) {
+	private Page<Coach> fetchCoachesPage(User user, List<Long> sportsList, String search, GenderEnum genderEnum,
+		Pageable pageable, Boolean review, Boolean liked, Boolean latest, Boolean my) {
 		Page<Coach> coachesPage;
 
 		if (Boolean.TRUE.equals(review)) {
-			coachesPage = coachRepository.findAllWithReviewsSorted(sportsList, search, pageable);
+			coachesPage = coachRepository.findAllWithReviewsSorted(sportsList, search, genderEnum, pageable);
 		} else if (Boolean.TRUE.equals(liked)) {
-			coachesPage = coachRepository.findAllWithLikesSorted(sportsList, search, pageable);
+			coachesPage = coachRepository.findAllWithLikesSorted(sportsList, search, genderEnum, pageable);
 		} else if (Boolean.TRUE.equals(latest)) {
-			coachesPage = coachRepository.findAllWithLatestSorted(sportsList, search, pageable);
+			coachesPage = coachRepository.findAllWithLatestSorted(sportsList, search, genderEnum, pageable);
 		} else if (Boolean.TRUE.equals(my)) {
-			coachesPage = coachRepository.findMyCoaches(user.getUserId(), sportsList, search, pageable);
+			coachesPage = coachRepository.findMyCoaches(user.getUserId(), sportsList, search, genderEnum, pageable);
 		} else {
-			coachesPage = coachRepository.findAllWithLatestSorted(sportsList, search, pageable);
+			coachesPage = coachRepository.findAllWithLatestSorted(sportsList, search, genderEnum, pageable);
 		}
 
 		List<Coach> filteredCoaches = coachesPage.getContent().stream()
@@ -432,7 +436,17 @@ public class CoachService {
 			.collect(Collectors.toList());
 
 		return new PageImpl<>(filteredCoaches, pageable, coachesPage.getTotalElements());
+	}
 
+	private GenderEnum parseGender(String gender) {
+		if (gender == null || gender.isEmpty()) {
+			return null;
+		}
+		try {
+			return GenderEnum.valueOf(gender.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("Invalid gender value: " + gender);
+		}
 	}
 
 	private CoachListDto getCoachListDto(Coach coach, User user) {

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -450,8 +450,9 @@ public class CoachService {
 	}
 
 	private CoachListDto getCoachListDto(Coach coach, User user) {
-		List<ReviewDto> reviews = getReviews(coach, user, ReviewSortOption.LATEST);
-		double averageRating = calculateAverageRating(reviews);
+		List<Review> reviews = reviewRepository.findByCoach_CoachId(coach.getCoachId());
+		double averageRating = reviews.stream().mapToInt(Review::getStars).average().orElse(0.0);
+		averageRating = Math.round(averageRating * 10.0) / 10.0;
 		int countOfReviews = reviews.size();
 
 		boolean isLiked = isLikedByUser(user, coach);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/CoachService.java
@@ -450,8 +450,8 @@ public class CoachService {
 	}
 
 	private CoachListDto getCoachListDto(Coach coach, User user) {
-		List<Review> reviews = reviewRepository.findByCoach_CoachId(coach.getCoachId());
-		double averageRating = reviews.stream().mapToInt(Review::getStars).average().orElse(0.0);
+		List<ReviewDto> reviews = getReviews(coach, user, ReviewSortOption.LATEST);
+		double averageRating = calculateAverageRating(reviews);
 		int countOfReviews = reviews.size();
 
 		boolean isLiked = isLikedByUser(user, coach);

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/PopularCoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/PopularCoachService.java
@@ -44,7 +44,8 @@ public class PopularCoachService {
 		boolean isLiked = userCoachLikeRepository
 			.existsByUser_UserIdAndCoach_CoachId(user.getUserId(), coach.getCoachId());
 		List<Review> reviews = reviewRepository.findByCoach_CoachId(coach.getCoachId());
-		double averageRating = calculateRoundedAverageRating(reviews);
+		double averageRating = reviews.stream().mapToInt(Review::getStars).average().orElse(0.0);
+		averageRating = Math.round(averageRating * 10.0) / 10.0;
 
 		return new PopularCoachDto(
 			coach.getCoachId(),
@@ -56,16 +57,5 @@ public class PopularCoachService {
 			isLiked,
 			coachingSports
 		);
-	}
-
-	private double calculateRoundedAverageRating(List<Review> reviews) {
-		if (reviews.isEmpty()) {
-			return 0.0;
-		}
-		double average = reviews.stream()
-			.mapToInt(Review::getStars)
-			.average()
-			.orElse(0.0);
-		return Math.round(average * 10) / 10.0; // 소수점 첫째 자리 반올림
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/PopularCoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/PopularCoachService.java
@@ -44,7 +44,7 @@ public class PopularCoachService {
 		boolean isLiked = userCoachLikeRepository
 			.existsByUser_UserIdAndCoach_CoachId(user.getUserId(), coach.getCoachId());
 		List<Review> reviews = reviewRepository.findByCoach_CoachId(coach.getCoachId());
-		double averageRating = reviews.stream().mapToInt(Review::getStars).average().orElse(0.0);
+		double averageRating = calculateRoundedAverageRating(reviews);
 
 		return new PopularCoachDto(
 			coach.getCoachId(),
@@ -56,5 +56,16 @@ public class PopularCoachService {
 			isLiked,
 			coachingSports
 		);
+	}
+
+	private double calculateRoundedAverageRating(List<Review> reviews) {
+		if (reviews.isEmpty()) {
+			return 0.0;
+		}
+		double average = reviews.stream()
+			.mapToInt(Review::getStars)
+			.average()
+			.orElse(0.0);
+		return Math.round(average * 10) / 10.0; // 소수점 첫째 자리 반올림
 	}
 }

--- a/src/main/java/site/coach_coach/coach_coach_server/coach/service/PopularCoachService.java
+++ b/src/main/java/site/coach_coach/coach_coach_server/coach/service/PopularCoachService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import site.coach_coach.coach_coach_server.coach.domain.Coach;
 import site.coach_coach.coach_coach_server.coach.dto.PopularCoachDto;
 import site.coach_coach.coach_coach_server.like.repository.UserCoachLikeRepository;
+import site.coach_coach.coach_coach_server.review.domain.Review;
+import site.coach_coach.coach_coach_server.review.repository.ReviewRepository;
 import site.coach_coach.coach_coach_server.sport.dto.CoachingSportDto;
 import site.coach_coach.coach_coach_server.user.domain.User;
 
@@ -21,6 +23,7 @@ import site.coach_coach.coach_coach_server.user.domain.User;
 public class PopularCoachService {
 
 	private final UserCoachLikeRepository userCoachLikeRepository;
+	private final ReviewRepository reviewRepository;
 
 	public List<PopularCoachDto> getTopCoaches(User user) {
 		LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
@@ -40,6 +43,8 @@ public class PopularCoachService {
 		int countOfLikes = userCoachLikeRepository.countByCoach_CoachId(coach.getCoachId());
 		boolean isLiked = userCoachLikeRepository
 			.existsByUser_UserIdAndCoach_CoachId(user.getUserId(), coach.getCoachId());
+		List<Review> reviews = reviewRepository.findByCoach_CoachId(coach.getCoachId());
+		double averageRating = reviews.stream().mapToInt(Review::getStars).average().orElse(0.0);
 
 		return new PopularCoachDto(
 			coach.getCoachId(),
@@ -47,6 +52,7 @@ public class PopularCoachService {
 			coach.getUser().getProfileImageUrl(),
 			coach.getCoachIntroduction(),
 			countOfLikes,
+			averageRating,
 			isLiked,
 			coachingSports
 		);

--- a/src/main/resources/db/migration/V22__add_total_user_count_column.sql
+++ b/src/main/resources/db/migration/V22__add_total_user_count_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `coachcoach`.`coaches`
+    ADD COLUMN `total_user_count` INT NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V22_add_total_user_count_column.sql
+++ b/src/main/resources/db/migration/V22_add_total_user_count_column.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `coachcoach`.`coaches`
-    ADD COLUMN `total_user_count` INT NOT NULL DEFAULT ０ AFTER `is_open`;


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 코치 리스트를 조회할 때 성별 필터를 추가함
  - 사용자가 제공한 성별에 맞는 코치들만 조회되도록 `User`의 `gender` 속성에 맞는 필터링 로직을 구현했습니다.
  - 성별 필터는 `CoachService`에서 `User` 객체의 성별을 받아서 해당 성별에 맞는 코치들만 조회하도록 수정되었습니다.
- 기타 Response 값 수정(프론트 요청)
  - 인기 코치 리스트 조회 API에 평점 컬럼 추가
  - 코치 디테일 조회 API에 리뷰수 추가
- v22 파일 수정

### PR Point
- 사용자가 제공한 성별에 따라 코치 목록을 필터링하여, 성별을 기반으로 한 맞춤형 코치 리스트를 제공.
- 평점, 리뷰수 컬럼 추가
  - 평점은 ReviewRepository를 통해 조회된 리뷰들에 대한 별점의 평균을 계산하고, 소수점 첫째 자리까지 반올림 처리함
  
### 📸 스크린샷
|사진|설명|
|--|--|
|![image](https://github.com/user-attachments/assets/a4f737d9-f4a6-489b-9891-b958d0a12d85)|`gender`=`w`|
|![image](https://github.com/user-attachments/assets/cfe64c65-b2d6-427e-ad7a-e4b3ee0e8a1e)|`gender`=`m`|
|![image](https://github.com/user-attachments/assets/39b261b3-c698-42a1-bbf9-be6725911eee)|코치 상세 정보 조회 시 `countOfReviews` 값 추가|
|![image](https://github.com/user-attachments/assets/dcc4b56c-9dc4-4967-96fa-1f04eabfbab4)|인기 코치 리스트 조회 시 `reviewRating` 값 추가|

### 논의 사항 (선택)
- QueryDSL을 사용하여 성별 필터링을 포함한 복잡한 쿼리를 처리하려고 했으나, 여러 가지 예상치 못한 이슈(QueryDSL 설정 문제, 쿼리 복잡성 등)가 발생하여 구현에 예상보다 시간이 더 소요될 것으로 판단되었습니다.
- 따라서, 우선 프로젝트 일정에 영향을 주지 않도록 기존 방식(JPQL)을 사용하여 성별 필터링 로직을 구현했습니다. 향후 QueryDSL을 적용할 수 있도록 리팩토링을 고려할 수 있으며, 현재로서는 안정성과 개발 속도를 우선시하여 진행하게 되었습니다.

closed #335
